### PR TITLE
CI/CD fixes for release branch detection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
       - run:
           name: login to Docker Hub
           command: echo "$DOCKER_PASS" | docker login --username "$DOCKER_USER" --password-stdin
-      - run: BRANCH=${CIRCLE_BRANCH} ID=circle PUSH_CACHE=1 ./ci/build.sh
+      - run: BRANCH=${CIRCLE_BRANCH:-$CIRCLE_TAG} ID=circle PUSH_CACHE=1 ./ci/build.sh
   
   test:
     executor: corerunner

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -6,7 +6,7 @@ action "Docker Registry Login" {
 
 action "Cached Build" {
   uses = "actions/docker/cli@master"
-  runs = ["sh", "-c", "BRANCH=${GITHUB_REF##*/} ID=gh ci/build.sh"]
+  runs = ["sh", "-c", "BRANCH=$GITHUB_REF ID=gh ci/build.sh"]
   needs = ["Docker Registry Login"]
   env = {
     PUSH_CACHE = "0"
@@ -15,7 +15,7 @@ action "Cached Build" {
 
 action "Caching Build" {
   uses = "actions/docker/cli@master"
-  runs = ["sh", "-c", "BRANCH=${GITHUB_REF##*/} ID=gh ci/build.sh"]
+  runs = ["sh", "-c", "BRANCH=$GITHUB_REF ID=gh ci/build.sh"]
   needs = ["Docker Registry Login"]
   env = {
     PUSH_CACHE = "1"

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -26,7 +26,21 @@ PUSH_CACHE=${PUSH_CACHE:-0}
 # fall back to trying to parse git locally. The latter may not work in many CI
 # Docker containers (since they don't contain git) so you likely want to make
 # sure this is passed in CI based on the particular host's methodology.
-BRANCH=${BRANCH:-$(git rev-parse --abbrev-ref HEAD)}
+#
+# As some systems will pass along tags as the branch, or even the full ref, we
+# strip anything passed in $BRANCH such that:
+#
+#   master                  -> [master]
+#   feature1                -> [feature1]
+#   refs/heads/feature1     -> [feature1]
+#   refs/tags/v1.0.3        -> [v1.0.3]
+#   refs/tags/v1.0.3-rc.1   -> [v1.0.3-rc.1]
+#
+if [ -n "$BRANCH" ]; then
+    BRANCH=${BRANCH##*/}
+else
+    BRANCH=$(git rev-parse --abbrev-ref HEAD)
+fi
 
 # Define full tags for both current branch and master branch. We want to be 
 # able to fall back to the last master branch build in the situation where


### PR DESCRIPTION
_For now, this is mostly a holding pen for me to document what we're seeing with the behavior of the release scripts is when they background run on our daily activity in master, and in the future will become iterative commits towards making changes to get things suited for automated release._

------

Debugging issues that only surface during release phase, which we previously could not test.

### Semaphore Release

https://openlaw.semaphoreci.com/workflows/b0cebfa6-43bf-4dcb-85fa-eca23f0f0bcf

Currently dying on first build step, because `$SEMAPHORE_GIT_BRANCH` gets set to `refs/tags/v0.1.30` which results build script generating an invalid buildcache tag name of `889468772737.dkr.ecr.eu-central-1.amazonaws.com/openlawteam/openlaw-core:buildcache-ol-refs/tags/v0.1.30` (extra slashes).

Available env vars to work with:
https://docs.semaphoreci.com/article/12-environment-variables#predefined-environment-variables

Will need to resolve before we can see how actual release script fares.

### CircleCI Release

https://circleci.com/workflow-run/9d21ba1f-69a2-42a6-a0a1-d9229cf11984

```
#!/bin/sh -eo pipefail
BRANCH=${CIRCLE_BRANCH} ID=circle PUSH_CACHE=1 ./ci/build.sh
./ci/build.sh: line 29: git: not found
Exited with code 127
```

Interestingly, that means it seems to not be getting the passed BRANCH env variable in this particular invocation, as otherwise it would not fall back to trying to use git to determine things (that's the fallback for supporting local development -- it's expected that git may not be installed in CI).

```bash
BRANCH=${BRANCH:-$(git rev-parse --abbrev-ref HEAD)}
```

 I will need to look into this and debug, strange it only happens during release, I suspect this may actually be another env var parsing issue. 😬 

### GitHub Actions Release
https://github.com/openlawteam/openlaw-core/actions/workflow-runs/MDEwOkNoZWNrU3VpdGUxMTM5NDg5MTQ=

Succeeds! 🎉 Or at least, gets up to the `$RELEASE_TRIGGER` check then bails as configured to do. Open question as to whether we'd need to put something in to handle the same 3x release tasks GitHub Actions "bug" we're seeing in openlaw-client (can test and backport any changes from there if we end up going this route.)