### PR TITLE
fix(ci): hardcode branch/refs parsing for semaphore

### DIFF
--- a/.semaphore/bintray-release.yml
+++ b/.semaphore/bintray-release.yml
@@ -23,11 +23,11 @@ blocks:
         commands:
           - checkout
           - aws ecr get-login --no-include-email | bash
-          - docker pull ${ECR_IMAGE}:buildcache-ol-${SEMAPHORE_GIT_BRANCH}
+          - docker pull ${ECR_IMAGE}:buildcache-ol-${SEMAPHORE_GIT_BRANCH##*/}
           - |
             docker run --rm -it \
               -v ${PWD}/.git:/src/.git \
               --env BINTRAY_USER=${BINTRAY_USER} \
               --env BINTRAY_PASS=${BINTRAY_PASS} \
               --env RELEASE_TRIGGER=${RELEASE_TRIGGER} \
-              ${ECR_IMAGE}:buildcache-ol-${SEMAPHORE_GIT_BRANCH} ./scripts/release.sh
+              ${ECR_IMAGE}:buildcache-ol-${SEMAPHORE_GIT_BRANCH##*/} ./scripts/release.sh

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -39,8 +39,8 @@ blocks:
       - name: Test
         commands:
           - aws ecr get-login --no-include-email | bash
-          - docker pull ${ECR_IMAGE}:buildcache-ol-${SEMAPHORE_GIT_BRANCH}
-          - docker run --rm -it ${ECR_IMAGE}:buildcache-ol-${SEMAPHORE_GIT_BRANCH} ./scripts/test.sh
+          - docker pull ${ECR_IMAGE}:buildcache-ol-${SEMAPHORE_GIT_BRANCH##*/}
+          - docker run --rm -it ${ECR_IMAGE}:buildcache-ol-${SEMAPHORE_GIT_BRANCH##*/} ./scripts/test.sh
 
       - name: Coverage report
         env_vars:
@@ -48,12 +48,12 @@ blocks:
             value: "0"
         commands:
           - aws ecr get-login --no-include-email | bash
-          - docker pull ${ECR_IMAGE}:buildcache-ol-${SEMAPHORE_GIT_BRANCH}
+          - docker pull ${ECR_IMAGE}:buildcache-ol-${SEMAPHORE_GIT_BRANCH##*/}
           - |
             docker run --rm -it \
             --env CODACY_PROJECT_TOKEN=${CODACY_PROJECT_TOKEN} \
             --env UPLOAD_RESULTS=${UPLOAD_RESULTS} \
-            ${ECR_IMAGE}:buildcache-ol-${SEMAPHORE_GIT_BRANCH} ./scripts/coverage_report.sh
+            ${ECR_IMAGE}:buildcache-ol-${SEMAPHORE_GIT_BRANCH##*/} ./scripts/coverage_report.sh
 
 promotions:
   - name: Release to Bintray


### PR DESCRIPTION
This is the fix built in to `build.sh`, but since semaphore doesn't have support for reusing containers in later steps, I had previously hardcoded the remote image name parsing for its steps, so it needs to be updated there as well anywhere the `$SEMAPHORE_GIT_BRANCH` is explicitly referenced other than when it gets passed into `build.sh`. 😠 
