### PR TITLE
fix(ci): circleci integration particulars

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,14 +51,20 @@ jobs:
     steps:
       - run: ./scripts/coverage_report.sh
 
+  # for release step, we need a .git directory, so do a local checkout.
+  # circleci prevents us from doing a checkout in a non-empty directory,
+  # so we need to override the WORKDIR of the container such that their
+  # built-in checkout will function, and then manually copy our files
+  # to where we need em.
   release:
     executor: corerunner
     environment:
       - RELEASE_TRIGGER: "false"
+    working_directory: /tmp/git-clone
     steps:
-      # for release step, need .git directory, so do a local checkout
       - checkout
-      - run: ./scripts/release.sh
+      - run: cp -r .git /src/.git
+      - run: cd /src && ./scripts/release.sh
 
 workflows:
   version: 2.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ executors:
     parameters:
       branchname:
         type: string
-        default: ${CIRCLE_BRANCH}
+        default: ${CIRCLE_BRANCH:-$CIRCLE_TAG}
 
 jobs:
   build:


### PR DESCRIPTION
Looks like we need this one other place for CircleCI. Unfortunately, I'm not 100% certain their YAML parser will allow variable transforms in this fashion, and I can't think of a way to test short of another
test release.

Test Plan:
If this doesn't break normal builds in CircleCI (should see in the PR checks, verify that is working first), we can try a test release from this branch before merging to master.