### PR TITLE
GH-135 - New variable type for external calls

### DIFF
--- a/shared/src/main/scala/org/adridadou/openlaw/oracles/ExternalCallOracle.scala
+++ b/shared/src/main/scala/org/adridadou/openlaw/oracles/ExternalCallOracle.scala
@@ -1,0 +1,141 @@
+package org.adridadou.openlaw.oracles
+
+import java.time.LocalDateTime
+
+import io.circe.{Decoder, Encoder}
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+import org.adridadou.openlaw.parser.template.{ActionIdentifier, ActionInfo, TemplateExecutionResult, VariableName}
+import org.adridadou.openlaw.parser.template.variableTypes._
+import org.adridadou.openlaw.vm.{OpenlawVm, OpenlawVmEvent}
+import slogging.LazyLogging
+import io.circe.syntax._
+import cats.implicits._
+import LocalDateTimeHelper._
+import org.adridadou.openlaw.OpenlawValue
+import org.adridadou.openlaw.result.{Failure, Result, Success}
+
+
+case class ExternalCallOracle(crypto: CryptoService) extends OpenlawOracle[ExternalCallEvent] with LazyLogging {
+
+  override def incoming(vm: OpenlawVm, event: ExternalCallEvent): Result[OpenlawVm] = event match {
+    case failedEvent: FailedExternalCallEvent =>
+      handleFailedEvent(vm, failedEvent)
+    case _ =>
+      handleEvent(vm, event)
+  }
+
+  private def handleEvent(vm: OpenlawVm, event: ExternalCallEvent): Result[OpenlawVm] = {
+    //TODO check signatures
+    vm.allActions.find(info => info.identifier === event.identifier).map { actionInfo =>
+        vm.executions[ExternalCallExecution](event.identifier).find(_.requestIdentifier === event.requestIdentifier) match {
+          case Some(execution) =>
+            Success(vm.newExecution(event.identifier, event.toExecution(execution.scheduledDate)))
+          case None =>
+            getScheduledDate(actionInfo, vm, event) match {
+              case Some(scheduleDate) =>
+                Success(vm.newExecution(event.identifier, event.toExecution(scheduleDate)))
+              case None =>
+                logger.warn(s"the external call ${event.requestIdentifier} has not been scheduled yet")
+                Success(vm)
+            }
+        }
+      }.getOrElse(Failure(s"action not found for event ${event.typeIdentifier}"))
+  }
+
+  private def handleFailedEvent(vm: OpenlawVm, event: FailedExternalCallEvent): Result[OpenlawVm] = {
+    val failedExecution = FailedExternalCallExecution(
+      scheduledDate = event.scheduledDate,
+      executionDate = event.executionDate,
+      errorMessage = event.errorMessage,
+      requestIdentifier = event.requestIdentifier)
+
+    Success(vm.newExecution(event.identifier, failedExecution))
+  }
+
+  private def getScheduledDate(info: ActionInfo, vm: OpenlawVm, event: ExternalCallEvent): Option[LocalDateTime] = {
+    vm.executions[ExternalCallExecution](info.identifier).find(_.requestIdentifier === event.requestIdentifier) match {
+      case Some(execution) =>
+        Some(execution.scheduledDate)
+      case None =>
+        info.action.nextActionSchedule(info.executionResult, vm.executions(event.identifier))
+    }
+  }
+
+  override def shouldExecute(event: OpenlawVmEvent): Boolean = event match {
+    case _: ExternalCallEvent => true
+    case _ => false
+  }
+}
+
+object PendingExternalCallEvent {
+  implicit val pendingExternalCallEventEnc: Encoder[PendingExternalCallEvent] = deriveEncoder[PendingExternalCallEvent]
+  implicit val pendingExternalCallEventDec: Decoder[PendingExternalCallEvent] = deriveDecoder[PendingExternalCallEvent]
+}
+
+object FailedExternalCallEvent {
+  implicit val failedExternalCallEventEnc: Encoder[FailedExternalCallEvent] = deriveEncoder[FailedExternalCallEvent]
+  implicit val failedExternalCallEventDec: Decoder[FailedExternalCallEvent] = deriveDecoder[FailedExternalCallEvent]
+}
+
+object SuccessfulExternalCallEvent {
+  implicit val successfulExternalCallEventEnc: Encoder[SuccessfulExternalCallEvent] = deriveEncoder[SuccessfulExternalCallEvent]
+  implicit val successfulExternalCallEventDec: Decoder[SuccessfulExternalCallEvent] = deriveDecoder[SuccessfulExternalCallEvent]
+}
+
+sealed trait ExternalCallEvent extends OpenlawVmEvent {
+  val identifier:ActionIdentifier
+  val requestIdentifier: RequestIdentifier
+  val executionDate: LocalDateTime
+  def toExecution(scheduledDate:LocalDateTime):ExternalCallExecution
+}
+
+final case class PendingExternalCallEvent(identifier: ActionIdentifier,
+                                          requestIdentifier: RequestIdentifier,
+                                          executionDate: LocalDateTime) extends ExternalCallEvent {
+  override def typeIdentifier: String = className[PendingExternalCallEvent]
+
+  override def serialize: String = this.asJson.noSpaces
+
+  override def toExecution(scheduledDate: LocalDateTime): ExternalCallExecution = PendingExternalCallExecution(
+    scheduledDate = scheduledDate,
+    executionDate = executionDate,
+    requestIdentifier = requestIdentifier
+  )
+}
+
+final case class FailedExternalCallEvent(identifier: ActionIdentifier,
+                                         requestIdentifier: RequestIdentifier,
+                                         executionDate: LocalDateTime,
+                                         scheduledDate: LocalDateTime,
+                                         errorMessage: String) extends ExternalCallEvent {
+  override def typeIdentifier: String = className[FailedEthereumSmartContractCallEvent]
+
+  override def serialize: String = this.asJson.noSpaces
+
+  override def toExecution(scheduledDate: LocalDateTime): ExternalCallExecution = FailedExternalCallExecution(
+    scheduledDate = scheduledDate,
+    executionDate = executionDate,
+    errorMessage = errorMessage,
+    requestIdentifier = requestIdentifier
+  )
+}
+
+
+final case class SuccessfulExternalCallEvent(identifier: ActionIdentifier,
+                                             requestIdentifier: RequestIdentifier,
+                                             executionDate: LocalDateTime,
+                                             result: String) extends ExternalCallEvent {
+  override def typeIdentifier: String = className[SuccessfulExternalCallEvent]
+
+  override def serialize: String = this.asJson.noSpaces
+
+  def results(structure:DefinedStructureType, executionResult:TemplateExecutionResult): Map[VariableName, OpenlawValue] =
+    structure.cast(result, executionResult).underlying
+
+  override def toExecution(scheduledDate:LocalDateTime): ExternalCallExecution = SuccessfulExternalCallExecution(
+    scheduledDate = scheduledDate,
+    executionDate = executionDate,
+    result = result,
+    requestIdentifier = requestIdentifier
+  )
+}

--- a/shared/src/main/scala/org/adridadou/openlaw/parser/template/VariableDefinition.scala
+++ b/shared/src/main/scala/org/adridadou/openlaw/parser/template/VariableDefinition.scala
@@ -3,7 +3,7 @@ package org.adridadou.openlaw.parser.template
 import cats.Eq
 import org.adridadou.openlaw.parser.template.variableTypes._
 import cats.implicits._
-import io.circe.{Decoder, Encoder, KeyDecoder, KeyEncoder}
+import io.circe.{Decoder, Encoder, HCursor, Json, KeyDecoder, KeyEncoder}
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import org.adridadou.openlaw.OpenlawValue
 import org.adridadou.openlaw.parser.template.expressions.Expression
@@ -121,13 +121,16 @@ object VariableDefinition {
   def apply(name:VariableName):VariableDefinition =
     new VariableDefinition(name = name)
 
+  def apply(name:String, varType:VariableType):VariableDefinition =
+    VariableDefinition(name = VariableName(name), Some(VariableTypeDefinition(varType.name)))
+
   implicit val variableDefinitionEnc: Encoder[VariableDefinition] = deriveEncoder[VariableDefinition]
   implicit val variableDefinitionDec: Decoder[VariableDefinition] = deriveDecoder[VariableDefinition]
 }
 
 object VariableName {
-  implicit val variableNameEnc: Encoder[VariableName] = deriveEncoder[VariableName]
-  implicit val variableNameDec: Decoder[VariableName] = deriveDecoder[VariableName]
+  implicit val variableNameEnc: Encoder[VariableName] = (a: VariableName) => Json.fromString(a.name)
+  implicit val variableNameDec: Decoder[VariableName] = (c: HCursor) => c.as[String].map(n => VariableName(n))
   implicit val variableNameKeyEnc: KeyEncoder[VariableName] = (key: VariableName) => key.name
   implicit val variableNameKeyDec: KeyDecoder[VariableName] = (key: String) => Some(VariableName(key))
   implicit val variableNameEq:Eq[VariableName] = Eq.fromUniversalEquals

--- a/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/AbstractStructureType.scala
+++ b/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/AbstractStructureType.scala
@@ -104,20 +104,19 @@ case class DefinedStructureType(structure:Structure, typeName:String) extends Va
 
   override def getTypeClass: Class[OpenlawMap[VariableName, OpenlawValue]] = classOf[OpenlawMap[VariableName, OpenlawValue]]
 
-  override def keysType(keys: Seq[String], expression: Expression, executionResult: TemplateExecutionResult): Result[VariableType] = {
+  override def keysType(keys: Seq[String], expression: Expression, executionResult: TemplateExecutionResult): Result[VariableType] =
     keys.toList match {
       case Nil =>
         Success(AbstractStructureType)
-      case head::_ =>
+      case head::tail =>
         val name = VariableName(head)
         structure.typeDefinition.get(name) match {
           case Some(varDefinition) =>
-            varDefinition.varType(executionResult).keysType(keys, expression, executionResult)
+            varDefinition.varType(executionResult).keysType(tail, expression, executionResult)
           case None =>
             throw new RuntimeException(s"property '${keys.mkString(".")}' could not be resolved in structure value '$head'")
         }
     }
-  }
 
   override def validateKeys(name:VariableName, keys: Seq[String], expression:Expression, executionResult: TemplateExecutionResult): Result[Unit] = keys.toList match {
     case Nil =>

--- a/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/AbstractStructureType.scala
+++ b/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/AbstractStructureType.scala
@@ -1,19 +1,21 @@
 package org.adridadou.openlaw.parser.template.variableTypes
 
-import io.circe.{Decoder, Encoder, HCursor, Json}
+import cats.kernel.Eq
 import org.adridadou.openlaw.parser.template._
 import play.api.libs.json.JsObject
+import io.circe._
+import io.circe.generic.semiauto._
 import io.circe.syntax._
-import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import org.adridadou.openlaw._
 import org.adridadou.openlaw.parser.template.expressions.Expression
 import org.adridadou.openlaw.parser.template.formatters.{Formatter, NoopFormatter}
 import org.adridadou.openlaw.result.{Failure, Result, Success}
 
-
 object Structure {
   implicit val structureEnc:Encoder[Structure] = deriveEncoder[Structure]
   implicit val structureDec:Decoder[Structure] = deriveDecoder[Structure]
+
+  implicit val structureDecEq:Eq[Structure] = Eq.fromUniversalEquals
 }
 
 
@@ -46,7 +48,7 @@ case object AbstractStructureType extends VariableType(name = "Structure") with 
 
   def thisType: VariableType = AbstractStructureType
 
-  override def generateType(name: VariableName, structure: Structure): VariableType =
+  override def generateType(name: VariableName, structure: Structure): DefinedStructureType =
     DefinedStructureType(structure, name.name)
 
   private def getField(name:String, value:Parameter, executionResult: TemplateExecutionResult): Result[VariableDefinition] = value match {
@@ -55,7 +57,6 @@ case object AbstractStructureType extends VariableType(name = "Structure") with 
     case OneValueParameter(definition:VariableDefinition) =>
       Success(definition.copy(name = VariableName(name)))
     case param =>
-      println(param)
       Failure("error in the constructor for Structured Type")
   }
 }

--- a/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/ExternalCall.scala
+++ b/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/ExternalCall.scala
@@ -1,0 +1,127 @@
+package org.adridadou.openlaw.parser.template.variableTypes
+
+import java.time.temporal.ChronoUnit
+import java.time.{Clock, LocalDateTime, ZoneOffset}
+
+import cats.implicits._
+import cats.kernel.Eq
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+import io.circe._
+import org.adridadou.openlaw.{OpenlawDateTime, OpenlawNativeValue, OpenlawString, OpenlawValue, result}
+import org.adridadou.openlaw.parser.template._
+import org.adridadou.openlaw.parser.template.expressions.Expression
+import org.adridadou.openlaw.parser.template.variableTypes.LocalDateTimeHelper._
+import org.adridadou.openlaw.parser.template.variableTypes.VariableType._
+import org.adridadou.openlaw.result.{Failure, Success}
+import org.adridadou.openlaw.vm.OpenlawExecutionEngine
+
+object IntegratedServiceDefinition {
+  val parser = new OpenlawTemplateLanguageParserService(Clock.systemUTC())
+  val engine = new OpenlawExecutionEngine()
+
+  def apply(definition:String):result.Result[IntegratedServiceDefinition] = {
+    for {
+      i <- getStructure(definition, "Input")
+      o <- getStructure(definition, "Output")
+    } yield new IntegratedServiceDefinition(i, o)
+  }
+
+  private def getStructure(input:String, variableTypeName:String):result.Result[Structure] = {
+    parser.compileTemplate(input)
+      .flatMap(template => engine.execute(template))
+      .map(_.findVariableType(VariableTypeDefinition(variableTypeName)))
+      .flatMap({
+        case Some(t:DefinedStructureType) => Success(t.structure)
+        case Some(_) => Failure("invalid type")
+        case None => Failure(s"no type found named $variableTypeName")
+      })
+  }
+
+  implicit val integratedServiceDefinitionEnc:Encoder[IntegratedServiceDefinition] = deriveEncoder[IntegratedServiceDefinition]
+  implicit val integratedServiceDefinitionDec:Decoder[IntegratedServiceDefinition] = deriveDecoder[IntegratedServiceDefinition]
+  implicit val integratedServiceDefinitionEq:Eq[IntegratedServiceDefinition] = Eq.fromUniversalEquals
+}
+
+object ServiceName {
+  implicit val serviceNameEnc:Encoder[ServiceName] = (sn: ServiceName) => Json.fromString(sn.serviceName)
+  implicit val serviceNameDec:Decoder[ServiceName] = (c: HCursor) =>  for { name <- c.downField("serviceName").as[String] } yield ServiceName(name)
+  implicit val serviceNameKeyEnc:KeyEncoder[ServiceName] = (key: ServiceName) => key.serviceName
+  implicit val serviceNameKeyDec:KeyDecoder[ServiceName] = (key: String) => Some(ServiceName(key))
+
+  implicit val serviceNameEq:Eq[ServiceName] = Eq.fromUniversalEquals
+}
+
+case class ServiceName(serviceName:String)
+
+case class IntegratedServiceDefinition(input:Structure, output:Structure) {
+  def definedInput: DefinedStructureType = DefinedStructureType(input, "Input")
+  def definedOutput: DefinedStructureType = DefinedStructureType(output, "Output")
+}
+
+case class ExternalCall(serviceName: Expression,
+                        parameters: Map[VariableName, Expression],
+                        startDate: Option[Expression],
+                        endDate: Option[Expression],
+                        every: Option[Expression]) extends ActionValue with OpenlawNativeValue {
+
+  override def identifier(executionResult: TemplateExecutionResult): ActionIdentifier = {
+    val value = serviceName.evaluateT[OpenlawString](executionResult).getOrElse("") + "#" +
+    parameters.toSeq
+      .sortBy({case (key,_) => key.name})
+        .map({case (key, v) => v.evaluate(executionResult).map(key.name + "->" + _).getOrElse("")})
+        .mkString("#")
+
+      ActionIdentifier(value)
+  }
+
+  def getServiceName(executionResult: TemplateExecutionResult): String =
+    getString(serviceName, executionResult)
+
+  def getParameters(executionResult: TemplateExecutionResult): Map[VariableName, OpenlawValue] =
+    parameters.flatMap({
+      case (name, expr) => expr.evaluate(executionResult).map(name -> _)
+    })
+
+  def getStartDate(executionResult: TemplateExecutionResult): Option[LocalDateTime] =
+    startDate.map(getDate(_, executionResult).underlying)
+
+  def getEndDate(executionResult: TemplateExecutionResult): Option[LocalDateTime] =
+    endDate.map(getDate(_, executionResult).underlying)
+
+  def getEvery(executionResult: TemplateExecutionResult): Option[Period] =
+    every.map(getPeriod(_, executionResult))
+
+  override def nextActionSchedule(executionResult: TemplateExecutionResult, pastExecutions: Seq[OpenlawExecution]): Option[LocalDateTime] = {
+    val executions = pastExecutions.map(VariableType.convert[ExternalCallExecution])
+    val callToReRun = executions
+      .map(VariableType.convert[ExternalCallExecution])
+      .find(execution => execution.executionStatus match {
+        case FailedExecution =>
+          execution.executionDate
+            .isBefore(LocalDateTime.now(executionResult.clock).minus(5, ChronoUnit.MINUTES))
+        case _ =>
+          false
+      }).map(_.scheduledDate)
+
+    callToReRun orElse {
+      executions.map(_.scheduledDate).toList match {
+        case Nil =>
+          Some(getStartDate(executionResult).getOrElse(LocalDateTime.now(executionResult.clock)))
+        case list =>
+          val lastDate = list.maxBy(_.toEpochSecond(ZoneOffset.UTC))
+          getEvery(executionResult).flatMap(schedulePeriod => {
+            DateTimeType
+              .plus(Some(lastDate), Some(schedulePeriod), executionResult)
+              .map(VariableType.convert[OpenlawDateTime](_).underlying)
+              .filter(nextDate => getEndDate(executionResult).forall(date => nextDate.isBefore(date) || nextDate === date))
+          })
+      }
+    }
+  }
+
+}
+
+object ExternalCall {
+  implicit val externalCallEnc: Encoder[ExternalCall] = deriveEncoder[ExternalCall]
+  implicit val externalCallDec: Decoder[ExternalCall] = deriveDecoder[ExternalCall]
+}

--- a/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/ExternalCallType.scala
+++ b/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/ExternalCallType.scala
@@ -1,0 +1,160 @@
+package org.adridadou.openlaw.parser.template.variableTypes
+
+import io.circe.parser._
+import io.circe.syntax._
+import org.adridadou.openlaw.{OpenlawString, OpenlawValue}
+import org.adridadou.openlaw.parser.template._
+import org.adridadou.openlaw.parser.template.expressions.Expression
+import org.adridadou.openlaw.parser.template.formatters.{Formatter, NoopFormatter}
+import org.adridadou.openlaw.result.{Failure, Result, Success, attempt}
+
+case object ExternalCallType extends VariableType("ExternalCall") with ActionType {
+
+  case class PropertyDef(typeDef: VariableType, data: Seq[ExternalCallExecution] => Option[OpenlawValue])
+
+  private val propertyDef: Map[String, PropertyDef] = Map[String, PropertyDef](
+    "status" -> PropertyDef(typeDef = TextType, _.headOption.map(_.executionStatus.name)),
+    "executionDate" -> PropertyDef(typeDef = DateTimeType, _.headOption.map(_.executionDate)))
+
+  override def cast(value: String, executionResult: TemplateExecutionResult): ExternalCall =
+    handleEither(decode[ExternalCall](value))
+
+  override def internalFormat(value: OpenlawValue): String = value match {
+    case call: ExternalCall =>
+      call.asJson.noSpaces
+  }
+
+  override def validateKeys(variableName: VariableName, keys: Seq[String], valueExpression: Expression, executionResult: TemplateExecutionResult): Result[Unit] = {
+    keys.toList match {
+      case Nil => Success.unit
+      case prop :: Nil => propertyDef.get(prop) match {
+        case Some(_) =>
+          Success.unit
+        case None if "result".equalsIgnoreCase(prop) =>
+          Success.unit
+        case None =>
+          Failure(s"unknown property $prop for ExternalExecution type")
+      }
+      case prop :: otherKeys if prop.equalsIgnoreCase("result") =>
+        valueExpression.evaluateT[ExternalCall](executionResult).flatMap(getIntegratedService(_, executionResult)) match {
+          case Some(integratedServiceDefinition) =>
+            val variableType = AbstractStructureType.generateType(variableName, integratedServiceDefinition.output)
+            variableType.validateKeys(variableName, otherKeys, valueExpression, executionResult)
+          case None =>
+            Failure(s"unable to get ${keys.mkString(".")} missing value or service definition")
+        }
+      case _ =>
+        Failure(s"unknown property ${keys.mkString(".")} for ExternalExecution type")
+    }
+  }
+
+  override def keysType(keys: Seq[String], valueExpression: Expression, executionResult: TemplateExecutionResult): Result[VariableType] = {
+    keys.toList match {
+      case Nil => Success(this)
+      case prop :: Nil => propertyDef.get(prop) match {
+        case Some(propDef) =>
+          Success(propDef.typeDef)
+        case None if "result".equalsIgnoreCase(prop) =>
+          Success(this)
+        case None =>
+          Failure(s"unknown property $prop for ExternalExecution type")
+      }
+      case prop :: otherKeys if prop.equalsIgnoreCase("result") =>
+        valueExpression.evaluateT[ExternalCall](executionResult).flatMap(getIntegratedService(_, executionResult)) match {
+          case Some(integratedServiceDefinition) =>
+            val variableType = AbstractStructureType.generateType(VariableName("Output"), integratedServiceDefinition.output)
+            variableType.keysType(otherKeys, valueExpression, executionResult)
+          case None =>
+            Failure(s"unable to get ${keys.mkString(".")} missing value or service definition")
+        }
+      case _ =>
+        Failure(s"unknown property ${keys.mkString(".")} for ExternalExecution type")
+    }
+  }
+
+  override def access(value: OpenlawValue, name: VariableName, keys: Seq[String], executionResult: TemplateExecutionResult): Result[Option[OpenlawValue]] = {
+    val actionIdentifier = VariableType.convert[ExternalCall](value).identifier(executionResult)
+    val executions = executionResult.executions.get(actionIdentifier).map(_.executionMap.values.toSeq)
+      .getOrElse(Seq())
+      .map(VariableType.convert[ExternalCallExecution])
+
+    keys.toList match {
+      case Nil => Success(Some(value))
+      case prop :: Nil => propertyDef.get(prop) match {
+        case Some(propDef) =>
+          Success(propDef.data(executions))
+        case None if "result".equalsIgnoreCase(prop) =>
+
+          getIntegratedService(VariableType.convert[ExternalCall](value), executionResult) match {
+            case Some(integratedServiceDefinition) =>
+              val variableType = AbstractStructureType.generateType(name, integratedServiceDefinition.output)
+              attempt(executions.flatMap({
+                case e:SuccessfulExternalCallExecution => Some(e)
+                case _ => None
+              }).map(_.result)
+                .map(variableType.cast(_, executionResult))
+                .headOption)
+            case None =>
+              Failure(s"unable to get ${keys.mkString(".")} missing value or service definition")
+          }
+        case None =>
+          Failure(s"unknown property $prop for ExternalExecution type")
+      }
+      case prop :: otherKeys if "result".equalsIgnoreCase(prop) =>
+        getIntegratedService(VariableType.convert[ExternalCall](value), executionResult) match {
+          case Some(integratedServiceDefinition) =>
+            val variableType = AbstractStructureType.generateType(name, integratedServiceDefinition.output)
+            executions.flatMap({
+              case e:SuccessfulExternalCallExecution => Some(e)
+              case _ => None
+            }).map(_.result)
+              .map(variableType.cast(_, executionResult))
+              .map(s => variableType.access(s, name, otherKeys, executionResult))
+              .headOption
+              .getOrElse(Success(None))
+          case None =>
+            Failure(s"unable to get ${keys.mkString(".")} missing value or service definition")
+        }
+      case _ =>
+        Failure(s"unknown property ${keys.mkString(".")} for ExternalExecution type")
+    }
+  }
+
+  private def getIntegratedService(externalCall: ExternalCall, executionResult: TemplateExecutionResult):Option[IntegratedServiceDefinition] =
+    externalCall.serviceName
+      .evaluateT[OpenlawString](executionResult)
+      .map(ServiceName(_))
+      .flatMap(executionResult.externalCallStructures.get)
+
+  override def defaultFormatter: Formatter = new NoopFormatter
+
+  override def construct(constructorParams: Parameter, executionResult: TemplateExecutionResult): Result[Option[ExternalCall]] = {
+    constructorParams match {
+      case Parameters(v) =>
+        val values = v.toMap
+        attempt(Some(ExternalCall(
+          serviceName = getExpression(values, "serviceName", "service", "name"),
+          parameters = getParameter(values, "parameters", "params", "arguments", "args").map(prepareMappingParameters(_, executionResult)).getOrElse(Map()),
+          startDate = values.get("startDate").map(name => getExpression(name)),
+          endDate = getParameter(values, "endDate").map(getExpression),
+          every = getParameter(values, "repeatEvery").map(getExpression)
+        )))
+      case _ =>
+        Failure("ExternalCall needs to get 'serviceName' and 'arguments' as constructor parameters")
+    }
+  }
+
+  private def prepareMappingParameters(parameter: Parameter, result: TemplateExecutionResult):Map[VariableName, Expression] = parameter match {
+    case mapping:MappingParameter =>
+      mapping.mapping
+    case _ =>
+      throw new RuntimeException(s"parameter 'parameters' should be a list of mapping values not ${parameter.getClass.getSimpleName}")
+  }
+
+  override def getTypeClass: Class[_ <: ExternalCall] = classOf[ExternalCall]
+
+  def thisType: VariableType = ExternalCallType
+
+  override def actionValue(value: OpenlawValue): ExternalCall = VariableType.convert[ExternalCall](value)
+}
+

--- a/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/TemplateType.scala
+++ b/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/TemplateType.scala
@@ -12,8 +12,8 @@ import org.adridadou.openlaw.parser.template.expressions.Expression
 import org.adridadou.openlaw.result.{Failure, Result, Success, attempt}
 import org.adridadou.openlaw.values._
 
-case class TemplateDefinition(name:TemplateSourceIdentifier, mappingInternal:Map[String, Expression] = Map(), path:Option[TemplatePath] = None) extends OpenlawNativeValue {
-  lazy val mapping: Map[VariableName, Expression] = mappingInternal.map({case (key,value) => VariableName(key) -> value})
+case class TemplateDefinition(name:TemplateSourceIdentifier, mappingInternal:Map[VariableName, Expression] = Map(), path:Option[TemplatePath] = None) extends OpenlawNativeValue {
+  lazy val mapping: Map[VariableName, Expression] = mappingInternal.map({case (key,value) => key -> value})
 }
 
 case class TemplateSourceIdentifier(name:TemplateTitle)
@@ -120,7 +120,7 @@ case object TemplateType extends VariableType("Template") with NoShowInForm {
   def prepareTemplateSource(mappingParameter: Parameters, executionResult: TemplateExecutionResult, parameters: Map[VariableName, Expression], path: Option[TemplatePath]):Result[TemplateDefinition] = {
     prepareTemplateName(mappingParameter, executionResult).flatMap({
       case Some(source) =>
-        Success(TemplateDefinition(name = source, path = path, mappingInternal = parameters.map({ case (key, value) => key.name -> value })))
+        Success(TemplateDefinition(name = source, path = path, mappingInternal = parameters))
       case None =>
         Failure("name cannot be resolved yet!")
     })

--- a/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/VariableType.scala
+++ b/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/VariableType.scala
@@ -27,7 +27,8 @@ trait NoShowInForm
 trait ActionValue {
   def nextActionSchedule(executionResult: TemplateExecutionResult, pastExecutions:Seq[OpenlawExecution]): Result[Option[LocalDateTime]]
   def identifier(executionResult:TemplateExecutionResult):Result[ActionIdentifier]
-  def executions(executionResult: TemplateExecutionResult):Result[Executions] = executionResult.executions.get(identifier(executionResult))
+  def executions(executionResult: TemplateExecutionResult):Result[Executions] =
+    identifier(executionResult).map(executionResult.executions.get(_))
 }
 
 trait ActionType extends NoShowInForm {

--- a/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/VariableType.scala
+++ b/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/VariableType.scala
@@ -27,7 +27,7 @@ trait NoShowInForm
 trait ActionValue {
   def nextActionSchedule(executionResult: TemplateExecutionResult, pastExecutions:Seq[OpenlawExecution]): Result[Option[LocalDateTime]]
   def identifier(executionResult:TemplateExecutionResult):Result[ActionIdentifier]
-  def executions(executionResult: TemplateExecutionResult):Result[Executions] =
+  def executions(executionResult: TemplateExecutionResult):Result[Option[Executions]] =
     identifier(executionResult).map(executionResult.executions.get(_))
 }
 
@@ -240,8 +240,8 @@ abstract class VariableType(val name: String) {
     (implicit ct1: ClassTag[U], ct2: ClassTag[V])
   : Result[Option[Y]] = {
     (for {
-      left <- EitherT(optLeft.map(convert[U]))
-      right <- EitherT(optRight.map(convert[V]))
+      left <- EitherT(optLeft.map(VariableType.convert[U]))
+      right <- EitherT(optRight.map(VariableType.convert[V]))
     } yield {
       if (operation.isDefinedAt(left -> right)) operation(left -> right)
       else Failure(s"no matching case in partial function for arguments $left and $right")

--- a/shared/src/main/scala/org/adridadou/openlaw/vm/OpenlawExecutionEngine.scala
+++ b/shared/src/main/scala/org/adridadou/openlaw/vm/OpenlawExecutionEngine.scala
@@ -20,16 +20,22 @@ class OpenlawExecutionEngine extends VariableExecutionEngine {
   /**
     * Entry point for simple agreements
     */
+  def execute(mainTemplate:CompiledTemplate):Result[OpenlawExecutionState] =
+    execute(mainTemplate, TemplateParameters(), Map(), Map(), Map(), Map(), None, None)
+
+  /**
+    * Entry point for simple agreements
+    */
   def execute(mainTemplate:CompiledTemplate, parameters:TemplateParameters):Result[OpenlawExecutionState] =
-    execute(mainTemplate, parameters, Map())
+    execute(mainTemplate, parameters, Map(), Map(), Map(), Map(), None, None)
 
   /**
     * Entry point. This is where you start the execution of the main template
     */
-  def execute(mainTemplate:CompiledTemplate, parameters:TemplateParameters, templates:Map[TemplateSourceIdentifier, CompiledTemplate]):Result[OpenlawExecutionState] =
-    execute(mainTemplate, parameters, templates, Map(), Map(), None, None)
+  def execute(mainTemplate:CompiledTemplate, parameters:TemplateParameters, templates:Map[TemplateSourceIdentifier, CompiledTemplate], externalCallStructures:Map[ServiceName, IntegratedServiceDefinition] = Map()):Result[OpenlawExecutionState] =
+    execute(mainTemplate, parameters, templates, Map(), Map(), externalCallStructures, None, None)
 
-  def execute(mainTemplate:CompiledTemplate, parameters:TemplateParameters, templates:Map[TemplateSourceIdentifier, CompiledTemplate], signatureProofs:Map[Email, OpenlawSignatureProof], executions:Map[ActionIdentifier, Executions], id:Option[ContractId], profileAddress:Option[EthereumAddress]):Result[OpenlawExecutionState] = {
+  def execute(mainTemplate:CompiledTemplate, parameters:TemplateParameters, templates:Map[TemplateSourceIdentifier, CompiledTemplate], signatureProofs:Map[Email, OpenlawSignatureProof], executions:Map[ActionIdentifier, Executions], externalCallStructures:Map[ServiceName, IntegratedServiceDefinition], id:Option[ContractId], profileAddress:Option[EthereumAddress]):Result[OpenlawExecutionState] = {
     val executionResult = OpenlawExecutionState(
       parameters = parameters,
       id = TemplateExecutionResultId(s"@@anonymous_main_template_id@@"),
@@ -41,7 +47,8 @@ class OpenlawExecutionEngine extends VariableExecutionEngine {
       variableRedefinition = mainTemplate.redefinition,
       remainingElements = mutable.Buffer(mainTemplate.block.elems:_*),
       clock = mainTemplate.clock,
-      signatureProofs = signatureProofs
+      signatureProofs = signatureProofs,
+      externalCallStructures = externalCallStructures
     )
 
     resumeExecution(executionResult, templates)
@@ -167,6 +174,7 @@ class OpenlawExecutionEngine extends VariableExecutionEngine {
 
     case ConditionalBlock(subBlock, elseSubBlock, expr) =>
       executeConditionalBlock(executionResult, templates, subBlock, elseSubBlock, expr)
+
     case foreachBlock:ForEachBlock =>
       executeForEachBlock(executionResult, foreachBlock)
 

--- a/shared/src/main/scala/org/adridadou/openlaw/vm/OpenlawVmProvider.scala
+++ b/shared/src/main/scala/org/adridadou/openlaw/vm/OpenlawVmProvider.scala
@@ -2,12 +2,12 @@ package org.adridadou.openlaw.vm
 
 import org.adridadou.openlaw.oracles.{CryptoService, OpenlawOracle, OpenlawSignatureOracle}
 import org.adridadou.openlaw.parser.template.OpenlawTemplateLanguageParserService
-import org.adridadou.openlaw.parser.template.variableTypes.EthereumAddress
+import org.adridadou.openlaw.parser.template.variableTypes.{EthereumAddress, IntegratedServiceDefinition, ServiceName}
 import org.adridadou.openlaw.values.ContractDefinition
 
 class OpenlawVmProvider(cryptoService: CryptoService, parser:OpenlawTemplateLanguageParserService) {
 
-  def create(contractDefinition: ContractDefinition, profileAddress:Option[EthereumAddress], identityOracle:OpenlawSignatureOracle, executionOracles:Seq[OpenlawOracle[_]]):OpenlawVm =
-    OpenlawVm(contractDefinition, profileAddress, cryptoService, parser, identityOracle, executionOracles)
+  def create(contractDefinition: ContractDefinition, profileAddress:Option[EthereumAddress], identityOracle:OpenlawSignatureOracle, executionOracles:Seq[OpenlawOracle[_]], externalCallStructures: Map[ServiceName, IntegratedServiceDefinition] = Map()):OpenlawVm =
+    OpenlawVm(contractDefinition, profileAddress, cryptoService, parser, identityOracle, executionOracles, externalCallStructures)
 
 }

--- a/shared/src/test/scala/org/adridadou/openlaw/oracles/ExternalCallOracleSpec.scala
+++ b/shared/src/test/scala/org/adridadou/openlaw/oracles/ExternalCallOracleSpec.scala
@@ -6,6 +6,7 @@ import org.adridadou.openlaw.parser.template.variableTypes.RequestIdentifier
 import org.adridadou.openlaw.{OpenlawMap, OpenlawValue}
 import org.adridadou.openlaw.parser.template.{ActionIdentifier, OpenlawTemplateLanguageParserService, VariableName, VariableTypeDefinition}
 import org.adridadou.openlaw.result.{Failure, Success}
+import org.adridadou.openlaw.result.Implicits.RichResult
 import org.adridadou.openlaw.values.{ContractDefinition, TemplateId, TemplateParameters}
 import org.adridadou.openlaw.vm.{OpenlawExecutionEngine, OpenlawVmProvider, TestAccount, TestCryptoService}
 import org.scalatest.check.Checkers
@@ -42,7 +43,7 @@ class ExternalCallOracleSpec extends FlatSpec with Matchers with Checkers {
   private val pendingExecutionCallEvent = PendingExternalCallEvent(ActionIdentifier("pendingExternalCall"),
     requestIdentifier, LocalDateTime.parse("2018-12-12T00:00:00"))
   private val successExecutionCallEvent = SuccessfulExternalCallEvent(ActionIdentifier("successExternalCall"),
-    requestIdentifier, LocalDateTime.parse("2018-12-12T00:00:00"), structure.internalFormat(structureValues))
+    requestIdentifier, LocalDateTime.parse("2018-12-12T00:00:00"), structure.internalFormat(structureValues).getOrThrow())
 
   private val template =
     """

--- a/shared/src/test/scala/org/adridadou/openlaw/oracles/ExternalCallOracleSpec.scala
+++ b/shared/src/test/scala/org/adridadou/openlaw/oracles/ExternalCallOracleSpec.scala
@@ -1,0 +1,83 @@
+package org.adridadou.openlaw.oracles
+
+import java.time.{Clock, LocalDateTime}
+
+import org.adridadou.openlaw.parser.template.variableTypes.RequestIdentifier
+import org.adridadou.openlaw.{OpenlawMap, OpenlawValue}
+import org.adridadou.openlaw.parser.template.{ActionIdentifier, OpenlawTemplateLanguageParserService, VariableName, VariableTypeDefinition}
+import org.adridadou.openlaw.result.{Failure, Success}
+import org.adridadou.openlaw.values.{ContractDefinition, TemplateId, TemplateParameters}
+import org.adridadou.openlaw.vm.{OpenlawExecutionEngine, OpenlawVmProvider, TestAccount, TestCryptoService}
+import org.scalatest.check.Checkers
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.util.Random
+
+class ExternalCallOracleSpec extends FlatSpec with Matchers with Checkers {
+  private val clock = Clock.systemUTC()
+  private val parser:OpenlawTemplateLanguageParserService = new OpenlawTemplateLanguageParserService(clock)
+  private val engine = new OpenlawExecutionEngine()
+  private val vmProvider: OpenlawVmProvider = new OpenlawVmProvider(TestCryptoService, new OpenlawTemplateLanguageParserService(Clock.systemUTC()))
+  private val serverAccount: TestAccount = TestAccount.newRandom
+  private val oracle: ExternalCallOracle = ExternalCallOracle(TestCryptoService)
+
+  private val structureTemplate =
+    """
+      |[[MyCallType:Structure(
+      |computationResult: Text
+      |)]]
+    """.stripMargin
+
+  private val Success(executionResult) = parser.compileTemplate(structureTemplate, clock)
+    .flatMap(t => engine.execute(t))
+
+  private val Some(structure) = executionResult.findVariableType(VariableTypeDefinition("MyCallType"))
+
+  private val requestIdentifier = RequestIdentifier(Random.nextString(10))
+
+  private val structureValues:OpenlawMap[VariableName, OpenlawValue] = OpenlawMap(Map(VariableName("computationResult") -> "value"))
+
+  private val failExecutionCallEvent = FailedExternalCallEvent(ActionIdentifier("failedExternalCall"),
+    requestIdentifier, LocalDateTime.parse("2018-12-12T00:00:00"), LocalDateTime.parse("2018-12-12T00:10:00"), "some error")
+  private val pendingExecutionCallEvent = PendingExternalCallEvent(ActionIdentifier("pendingExternalCall"),
+    requestIdentifier, LocalDateTime.parse("2018-12-12T00:00:00"))
+  private val successExecutionCallEvent = SuccessfulExternalCallEvent(ActionIdentifier("successExternalCall"),
+    requestIdentifier, LocalDateTime.parse("2018-12-12T00:00:00"), structure.internalFormat(structureValues))
+
+  private val template =
+    """
+      |[[param1:Text]]
+      |[[param2:Text]]
+      |[[externalCall:ExternalCall(
+      |serviceName: "SomeIntegratedService";
+      |args:
+      |param1 -> param1,
+      |param2 -> param2;
+      |startDate: '2018-12-12 00:00:00';
+      |endDate: '2048-12-12 00:00:00';
+      |repeatEvery: '1 hour 30 minute')]]
+      |[[externalCall]]
+    """.stripMargin
+
+  private val templateId = TemplateId(TestCryptoService.sha256(template))
+  private val definition = ContractDefinition(UserId("hello@world.com"), templateId, Map(), TemplateParameters("param1" -> "a", "param2" -> "b"))
+  private val vm = vmProvider.create(definition, None, OpenlawSignatureOracle(TestCryptoService, serverAccount.address), Seq(oracle))
+
+  vm(LoadTemplate(template))
+
+  "ExternalCallOracle" should "execute external call events only" in {
+    oracle.shouldExecute(failExecutionCallEvent) shouldBe true
+    oracle.shouldExecute(pendingExecutionCallEvent) shouldBe true
+    oracle.shouldExecute(successExecutionCallEvent) shouldBe true
+  }
+
+  it should "handle a failed execution call event" in {
+    oracle.incoming(vm, failExecutionCallEvent) match {
+      case Right(newVm) =>
+        newVm.allExecutions.keys should contain(ActionIdentifier("failedExternalCall"))
+      case Failure(ex, message) =>
+        fail(message, ex)
+    }
+  }
+
+}

--- a/shared/src/test/scala/org/adridadou/openlaw/parser/OpenlawTemplateLanguageParserSpec.scala
+++ b/shared/src/test/scala/org/adridadou/openlaw/parser/OpenlawTemplateLanguageParserSpec.scala
@@ -7,7 +7,7 @@ import org.adridadou.openlaw.parser.contract.ParagraphEdits
 import org.adridadou.openlaw.parser.template._
 import org.adridadou.openlaw.parser.template.variableTypes._
 import org.adridadou.openlaw.result.{Failure, Result, Success}
-import org.adridadou.openlaw.result.Implicits.{failureCause2Exception, RichResultNel}
+import org.adridadou.openlaw.result.Implicits.{failureCause2Exception, RichResult, RichResultNel}
 import org.adridadou.openlaw.values.TemplateParameters
 import org.adridadou.openlaw.vm.OpenlawExecutionEngine
 import org.scalatest._
@@ -1597,10 +1597,10 @@ here""".stripMargin
           Map(ServiceName("FakeServiceInput") -> IntegratedServiceDefinition(inputStructureType, outputStructureType)))
 
         newExecutionResult.getVariables(ExternalCallType).size shouldBe 1
-        val allActions = executionResult.allActions
+        val allActions = executionResult.allActions.getOrThrow()
         allActions.size shouldBe 1
 
-        val call = executionResult.getVariableValues[ExternalCall](ExternalCallType).head
+        val call = executionResult.getVariableValues[ExternalCall](ExternalCallType).getOrThrow().head
         call.serviceName.asInstanceOf[StringConstant].value shouldBe "FakeServiceInput"
         call.parameters.map(_.toString) shouldBe List("(param1,var1)", "(param2,var2)")
         call.startDate.map(_.toString) shouldBe Some("\"2018-12-12 00:00:00\"")

--- a/shared/src/test/scala/org/adridadou/openlaw/parser/template/variabletypes/ExternalCallTypeSpec.scala
+++ b/shared/src/test/scala/org/adridadou/openlaw/parser/template/variabletypes/ExternalCallTypeSpec.scala
@@ -1,0 +1,46 @@
+package org.adridadou.openlaw.parser.template.variabletypes
+
+import org.adridadou.openlaw.parser.template.variableTypes.{IntegratedServiceDefinition, NumberType, ServiceName}
+import org.scalatest.{FlatSpec, Matchers}
+import io.circe.parser._
+import io.circe.syntax._
+import org.adridadou.openlaw.parser.template.{VariableDefinition, VariableName, VariableTypeDefinition}
+import org.adridadou.openlaw.result.Success
+
+class ExternalCallTypeSpec extends FlatSpec with Matchers {
+
+  "ServiceName" should "be decoded from json" in {
+    val json =
+      """
+        |{
+        | "serviceName": "this is a test"
+        |}
+      """.stripMargin
+
+    decode[ServiceName](json) match {
+      case Right(service) => service.serviceName shouldBe "this is a test"
+      case Left(err) => fail(err)
+    }
+  }
+
+  "IntegratedServiceDefinition" should "be decoded from json" in {
+    val Success(definition) = IntegratedServiceDefinition(
+      """
+        |[[Input:Structure(numberA: Number;
+        |numberB: Number)]]
+        |
+        |[[Output:Structure(result: Number)]]
+      """.stripMargin)
+
+    val json = definition.asJson.noSpaces
+
+    decode[IntegratedServiceDefinition](json) match {
+      case Right(isd) =>
+        isd.input.typeDefinition shouldBe Map(VariableName("numberA") -> VariableDefinition("numberA", NumberType), VariableName("numberB") -> VariableDefinition("numberB", NumberType))
+        isd.output.typeDefinition shouldBe Map(VariableName("result") -> VariableDefinition("result", NumberType))
+      case Left(err) =>
+        fail(err)
+    }
+  }
+
+}

--- a/shared/src/test/scala/org/adridadou/openlaw/parser/template/variabletypes/ExternalCallTypeSpec.scala
+++ b/shared/src/test/scala/org/adridadou/openlaw/parser/template/variabletypes/ExternalCallTypeSpec.scala
@@ -1,13 +1,26 @@
 package org.adridadou.openlaw.parser.template.variabletypes
 
-import org.adridadou.openlaw.parser.template.variableTypes.{IntegratedServiceDefinition, NumberType, ServiceName}
+import java.time.{Clock, LocalDateTime}
+
+import org.adridadou.openlaw.parser.template.variableTypes._
 import org.scalatest.{FlatSpec, Matchers}
 import io.circe.parser._
 import io.circe.syntax._
-import org.adridadou.openlaw.parser.template.{VariableDefinition, VariableName, VariableTypeDefinition}
-import org.adridadou.openlaw.result.Success
+import org.adridadou.openlaw.{OpenlawBigDecimal, oracles}
+import org.adridadou.openlaw.oracles.{LoadTemplate, OpenlawSignatureOracle, UserId}
+import org.adridadou.openlaw.parser.template.{ActionIdentifier, ExecutionFinished, ExpressionParserService, OpenlawTemplateLanguageParserService, VariableDefinition, VariableName, VariableTypeDefinition, variableTypes}
+import org.adridadou.openlaw.result.{Failure, Success}
+import org.adridadou.openlaw.values.{ContractDefinition, ContractId, TemplateId, TemplateParameters}
+import org.adridadou.openlaw.vm.{ContractCreated, OpenlawVmProvider, TestAccount, TestCryptoService}
+import play.api.libs.json.Json
 
 class ExternalCallTypeSpec extends FlatSpec with Matchers {
+
+  val parser:OpenlawTemplateLanguageParserService = new OpenlawTemplateLanguageParserService(Clock.systemUTC())
+  val exprParser = new ExpressionParserService()
+  val vmProvider:OpenlawVmProvider = new OpenlawVmProvider(TestCryptoService, parser)
+  val clock: Clock = Clock.systemUTC()
+  val serverAccount:TestAccount = TestAccount.newRandom
 
   "ServiceName" should "be decoded from json" in {
     val json =
@@ -29,7 +42,7 @@ class ExternalCallTypeSpec extends FlatSpec with Matchers {
         |[[Input:Structure(numberA: Number;
         |numberB: Number)]]
         |
-        |[[Output:Structure(result: Number)]]
+        |[[Output:Structure(sum: Number)]]
       """.stripMargin)
 
     val json = definition.asJson.noSpaces
@@ -37,10 +50,101 @@ class ExternalCallTypeSpec extends FlatSpec with Matchers {
     decode[IntegratedServiceDefinition](json) match {
       case Right(isd) =>
         isd.input.typeDefinition shouldBe Map(VariableName("numberA") -> VariableDefinition("numberA", NumberType), VariableName("numberB") -> VariableDefinition("numberB", NumberType))
-        isd.output.typeDefinition shouldBe Map(VariableName("result") -> VariableDefinition("result", NumberType))
+        isd.output.typeDefinition shouldBe Map(VariableName("sum") -> VariableDefinition("sum", NumberType))
       case Left(err) =>
         fail(err)
     }
   }
+
+  it should "" in {
+    val templateContent =
+      """<%
+        |[[numberA:Number]]
+        |[[numberB:Number]]
+        |[[externalCall:ExternalCall(
+        |serviceName: "Sum Service";
+        |parameters:
+        | numberA -> numberA,
+        | numberB -> numberB;
+        |startDate: '2018-12-12 00:00:00';
+        |endDate: '2048-12-12 00:00:00')]]
+        |%>
+        |
+        |[[identity:Identity]]
+        |
+        |[[externalCall.result.sum]]
+      """.stripMargin
+
+    val templateId = TemplateId(TestCryptoService.sha256(templateContent))
+    val email = Email("email@email.com")
+    val identity = Identity(email)
+    val definition = ContractDefinition(
+      creatorId = UserId("hello@world.com"),
+      mainTemplate = templateId,
+      templates = Map(),
+      parameters = TemplateParameters(
+        "identity" -> IdentityType.internalFormat(identity),
+        "numberA" -> NumberType.internalFormat(BigDecimal(2)),
+        "numberB" -> NumberType.internalFormat(BigDecimal(2))
+      )
+    )
+
+    val contractId = definition.id(TestCryptoService)
+    val Success(abi) = variableTypes.IntegratedServiceDefinition(
+      """[[Input:Structure(
+        |numberA: Number;
+        |numberB: Number
+        |)]]
+        |
+        |[[Output:Structure(
+        |sum:Number
+        |)]]
+        |""".stripMargin
+    )
+
+    val vm = vmProvider.create(definition, None, OpenlawSignatureOracle(TestCryptoService, serverAccount.address), Seq(), Map(ServiceName("Sum Service") -> abi))
+    vm(LoadTemplate(templateContent))
+    vm.executionResultState shouldBe ExecutionFinished
+    vm.executionState shouldBe ContractCreated
+
+    val signature = EthereumSignature(sign(identity, contractId).signature)
+    val signatureEvent = oracles.OpenlawSignatureEvent(contractId, email, "", signature, EthereumHash.empty)
+    vm(signatureEvent)
+
+    val identifier = ActionIdentifier("Sum Service#numberA->2#numberB->2")
+    val requestIdentifier = RequestIdentifier("test exec hash")
+
+    val pendingExternalCallEvent = oracles.PendingExternalCallEvent(identifier, requestIdentifier, LocalDateTime.now)
+    vm(pendingExternalCallEvent)
+
+    val jsonResponse = Json.obj("sum" -> "4")
+
+    val successfulExternalCallEvent = vm.executionResult match {
+      case Some(executionResult) =>
+        oracles.SuccessfulExternalCallEvent(identifier, requestIdentifier, LocalDateTime.now,
+          abi.definedOutput.internalFormat(abi.definedOutput.cast(jsonResponse.toString, executionResult)))
+      case None => fail("no execution result found!")
+    }
+
+    vm(successfulExternalCallEvent)
+    vm.getAllExecutedVariables(ExternalCallType).size shouldBe 1
+
+    val execution = variableTypes.SuccessfulExternalCallExecution(LocalDateTime.now, LocalDateTime.now, jsonResponse.toString, requestIdentifier)
+
+    val Some((exec, varDef)) = vm.newExecution(identifier, execution).getAllExecutedVariables(ExternalCallType).headOption
+
+    varDef.varType(exec).keysType(Seq("result", "sum"), varDef, exec) match {
+      case Success(variableType) => variableType.name shouldBe "Number"
+      case Failure(_, msg) => fail(msg)
+    }
+
+  }
+
+  private def sign(identity: Identity, contractId: ContractId): EthereumSignature =
+    signByEmail(identity.email, contractId.data)
+
+  private def signByEmail(email:Email, data:EthereumData):EthereumSignature =
+    EthereumSignature(serverAccount.sign(EthereumData(TestCryptoService.sha256(email.email))
+      .merge(EthereumData(TestCryptoService.sha256(data.data)))).signature)
 
 }

--- a/shared/src/test/scala/org/adridadou/openlaw/parser/template/variabletypes/ExternalCallTypeSpec.scala
+++ b/shared/src/test/scala/org/adridadou/openlaw/parser/template/variabletypes/ExternalCallTypeSpec.scala
@@ -8,7 +8,7 @@ import io.circe.parser._
 import io.circe.syntax._
 import org.adridadou.openlaw.{OpenlawBigDecimal, oracles}
 import org.adridadou.openlaw.oracles.{LoadTemplate, OpenlawSignatureOracle, UserId}
-import org.adridadou.openlaw.parser.template.{ActionIdentifier, ExecutionFinished, ExpressionParserService, OpenlawTemplateLanguageParserService, VariableDefinition, VariableName, VariableTypeDefinition, variableTypes}
+import org.adridadou.openlaw.parser.template.{ActionIdentifier, ExecutionFinished, ExpressionParserService, OpenlawTemplateLanguageParserService, VariableDefinition, VariableName, variableTypes}
 import org.adridadou.openlaw.result.{Failure, Success}
 import org.adridadou.openlaw.values.{ContractDefinition, ContractId, TemplateId, TemplateParameters}
 import org.adridadou.openlaw.vm.{ContractCreated, OpenlawVmProvider, TestAccount, TestCryptoService}

--- a/shared/src/test/scala/org/adridadou/openlaw/parser/template/variabletypes/ExternalCallTypeSpec.scala
+++ b/shared/src/test/scala/org/adridadou/openlaw/parser/template/variabletypes/ExternalCallTypeSpec.scala
@@ -56,7 +56,7 @@ class ExternalCallTypeSpec extends FlatSpec with Matchers {
     }
   }
 
-  it should "" in {
+  it should "access the parameters defined in the output abi" in {
     val templateContent =
       """<%
         |[[numberA:Number]]

--- a/shared/src/test/scala/org/adridadou/openlaw/vm/OpenlawExecutionEngineSpec.scala
+++ b/shared/src/test/scala/org/adridadou/openlaw/vm/OpenlawExecutionEngineSpec.scala
@@ -1337,15 +1337,15 @@ class OpenlawExecutionEngineSpec extends FlatSpec with Matchers {
         val Some(externalCall) = executionResult.getVariable("externalCall")
         val externalCallVarType = externalCall.varType(executionResult)
         externalCallVarType.getTypeClass shouldBe classOf[ExternalCall]
-        val Some(externalCallValue) = executionResult.getVariableValue[ExternalCall](VariableName("externalCall"))
-        externalCallValue.getServiceName(executionResult) shouldBe "SomeIntegratedService"
-        val arguments = externalCallValue.getParameters(executionResult)
+        val Some(externalCallValue) = executionResult.getVariableValue[ExternalCall](VariableName("externalCall")).getOrThrow()
+        externalCallValue.getServiceName(executionResult).getOrThrow() shouldBe "SomeIntegratedService"
+        val arguments = externalCallValue.getParameters(executionResult).getOrThrow()
         arguments.size shouldBe 2
         arguments(VariableName("param1")).underlying shouldBe "test1"
         arguments(VariableName("param2")).underlying shouldBe "test2"
-        externalCallValue.getStartDate(executionResult) shouldBe Some(LocalDateTime.parse("2018-12-12T00:00:00"))
-        externalCallValue.getEndDate(executionResult) shouldBe Some(LocalDateTime.parse("2048-12-12T00:00:00"))
-        externalCallValue.getEvery(executionResult) shouldBe Some(PeriodType.cast("1 hour 30 minute"))
+        externalCallValue.getStartDate(executionResult).getOrThrow() shouldBe Some(LocalDateTime.parse("2018-12-12T00:00:00"))
+        externalCallValue.getEndDate(executionResult).getOrThrow() shouldBe Some(LocalDateTime.parse("2048-12-12T00:00:00"))
+        externalCallValue.getEvery(executionResult).getOrThrow() shouldBe Some(PeriodType.cast("1 hour 30 minute").getOrThrow())
       case Left(ex) =>
         fail(ex.message, ex)
     }

--- a/shared/src/test/scala/org/adridadou/openlaw/vm/OpenlawVmSpec.scala
+++ b/shared/src/test/scala/org/adridadou/openlaw/vm/OpenlawVmSpec.scala
@@ -7,6 +7,7 @@ import org.adridadou.openlaw.oracles._
 import org.adridadou.openlaw.parser.template.{ActionIdentifier, ExecutionFinished, ExpressionParserService, OpenlawTemplateLanguageParserService, VariableName, variableTypes}
 import org.adridadou.openlaw.parser.template.variableTypes._
 import org.adridadou.openlaw.result.{Failure, Success}
+import org.adridadou.openlaw.result.Implicits.RichResult
 import org.adridadou.openlaw.values.{ContractDefinition, ContractId, TemplateId, TemplateParameters}
 import org.scalatest.{FlatSpec, Matchers}
 import org.scalatest.OptionValues._
@@ -413,16 +414,16 @@ class OpenlawVmSpec extends FlatSpec with Matchers {
       """.stripMargin
 
     val templateId = TemplateId(TestCryptoService.sha256(templateContent))
-    val email = Email("email@email.com")
+    val email = Email("email@email.com").getOrThrow()
     val identity = Identity(email)
     val definition = ContractDefinition(
       creatorId = UserId("hello@world.com"),
       mainTemplate = templateId,
       templates = Map(),
       parameters = TemplateParameters(
-        "identity" -> IdentityType.internalFormat(identity),
-        "param1" -> TextType.internalFormat("test value 1"),
-        "param2" -> TextType.internalFormat("test value 2")
+        "identity" -> IdentityType.internalFormat(identity).getOrThrow(),
+        "param1" -> TextType.internalFormat("test value 1").getOrThrow(),
+        "param2" -> TextType.internalFormat("test value 2").getOrThrow()
       )
     )
 
@@ -454,11 +455,11 @@ class OpenlawVmSpec extends FlatSpec with Matchers {
     val pendingExternalCallEvent = oracles.PendingExternalCallEvent(identifier, requestIdentifier, LocalDateTime.now)
     vm(pendingExternalCallEvent)
 
-    val externalResult = abi.definedOutput.internalFormat(OpenlawMap(Map(VariableName("computationResult") -> OpenlawString("Hello World"))))
+    val externalResult = abi.definedOutput.internalFormat(OpenlawMap(Map(VariableName("computationResult") -> OpenlawString("Hello World")))).getOrThrow()
     val successfulExternalCallEvent = oracles.SuccessfulExternalCallEvent(identifier, requestIdentifier, LocalDateTime.now, externalResult)
     vm(successfulExternalCallEvent)
 
-    vm.getAllExecutedVariables(ExternalCallType).size shouldBe 1
+    vm.getAllExecutedVariables(ExternalCallType).getOrThrow().size shouldBe 1
 
     val execution = variableTypes.SuccessfulExternalCallExecution(LocalDateTime.now, LocalDateTime.now, externalResult, requestIdentifier)
     vm.newExecution(identifier, execution)


### PR DESCRIPTION
Added a new variable type `ExternalCallType` so users can define the `ExternalCall` variable in the agreement to specify the service name and payload that needs to be computed by the target service.

The events are processed and validated via `ExternalCallOracle`.
