### PR TITLE
Set javac target

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,6 +36,7 @@ lazy val commonSettings = Seq(
   scalaVersion := scalaV,
   wartremoverErrors ++= rules,
   scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-language:implicitConversions"),
+  javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
 )
 
 lazy val publishSettings = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -31,12 +31,11 @@ lazy val repositories = Seq(
 )
 
 lazy val commonSettings = Seq(
-  scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature"),
   organization := "org.openlaw",
   name := "openlaw-core",
   scalaVersion := scalaV,
   wartremoverErrors ++= rules,
-  scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-language:implicitConversions")
+  scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-language:implicitConversions"),
 )
 
 lazy val publishSettings = Seq(


### PR DESCRIPTION
Since we build this as a library, explicitly set the javac target so no matter where it's built (e.g. a manual release), it produces reverse compatible files that will work across a variety of JDKs.