### PR TITLE
Divide Period

### DIFF
--- a/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/DateType.scala
+++ b/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/DateType.scala
@@ -95,8 +95,8 @@ abstract class DateTypeTrait(varTypeName:String, converter: (String, Clock) => O
     val years = tempDateTime.until(to, ChronoUnit.YEARS)
     tempDateTime = tempDateTime.plusYears(years)
 
-    val months = tempDateTime.until(to, ChronoUnit.MONTHS)
-    tempDateTime = tempDateTime.plusMonths(months)
+    val weeks = tempDateTime.until(to, ChronoUnit.WEEKS)
+    tempDateTime = tempDateTime.plusWeeks(weeks)
 
     val days = tempDateTime.until(to, ChronoUnit.DAYS)
     tempDateTime = tempDateTime.plusDays(days)
@@ -111,7 +111,7 @@ abstract class DateTypeTrait(varTypeName:String, converter: (String, Clock) => O
 
     Period(
       years = years.toInt,
-      months = months.toInt,
+      weeks = weeks.toInt,
       days = days.toInt,
       hours = hours.toInt,
       minutes = minutes.toInt,

--- a/shared/src/test/scala/org/adridadou/openlaw/vm/OpenlawExecutionEngineSpec.scala
+++ b/shared/src/test/scala/org/adridadou/openlaw/vm/OpenlawExecutionEngineSpec.scala
@@ -1439,4 +1439,37 @@ class OpenlawExecutionEngineSpec extends FlatSpec with Matchers with OptionValue
 
     VariableName("period").evaluateT[Period](result2) shouldBe period
   }
+
+  it should "be able to divide a period by a number" in {
+    val text=
+      """
+        |[[period:Period]]
+        |[[divisor:Number]]
+        |
+        |[[@newPeriod = period / divisor]]
+        |
+        |[[newPeriod]]
+      """.stripMargin
+
+    val template = compile(text)
+
+    val Right(result) = engine.execute(template, TemplateParameters(
+      "period" -> PeriodType.internalFormat(variableTypes.Period(
+        years = 1,
+        months = 2,
+        weeks = 3,
+        days = 4,
+        hours = 5,
+        minutes = 6)),
+      "divisor" -> "2"
+    ))
+
+    VariableName("newPeriod").evaluateT[Period](result) shouldBe Some(variableTypes.Period(
+      months = 7,
+      weeks = 1,
+      days = 5,
+      hours = 2,
+      minutes = 33
+    ))
+  }
 }


### PR DESCRIPTION
Period / Number

As discussed on Slack - division is prohibited when Period contains a month.

Date-Date also changed to return weeks/days instead of months