### PR TITLE
Checking missing inputs types that perform external calls

### DIFF
--- a/shared/src/main/scala/org/adridadou/openlaw/parser/template/StructuredDocument.scala
+++ b/shared/src/main/scala/org/adridadou/openlaw/parser/template/StructuredDocument.scala
@@ -575,13 +575,15 @@ case class OpenlawExecutionState(
 
       val (missingInputs, additionalErrors) = resultFromMissingInput(allMissingInput)
 
+      val serviceNamesErrors = missingServiceNames().map(varName => s"Invalid or missing property <$varName>")
+
       val validationErrors = validate.leftMap(nel => nel.map(_.message).toList).swap.getOrElse(Nil)
 
       ValidationResult(
         identities = identities.toList,
         missingInputs = missingInputs.toList,
         missingIdentities = missingIdentities,
-        validationExpressionErrors = validationErrors ++ additionalErrors ++ identitiesErrors
+        validationExpressionErrors = validationErrors ++ additionalErrors ++ identitiesErrors ++ serviceNamesErrors
       )
     }
   }
@@ -641,7 +643,7 @@ case class OpenlawExecutionState(
             }.getOrElse(s"${varDef.name}.serviceName")
           case _ => ""
         }
-      }.filter(_.nonEmpty).map(VariableName(_)).distinct
+      }.filter(_.nonEmpty).map(VariableName(_))
   }
 
   private def resultFromMissingInput(seq:Result[Seq[VariableName]]): (Seq[VariableName], Seq[String]) = seq match {

--- a/shared/src/test/scala/org/adridadou/openlaw/parser/OpenlawTemplateLanguageParserSpec.scala
+++ b/shared/src/test/scala/org/adridadou/openlaw/parser/OpenlawTemplateLanguageParserSpec.scala
@@ -1610,4 +1610,39 @@ here""".stripMargin
         fail(ex)
     }
   }
+
+  it should "provide the missingInput fields for identity type" in {
+    val text =
+      """
+        |[[Signatory: Identity]]
+      """.stripMargin
+
+    executeTemplate(text) match {
+      case Right(executionResult) =>
+        executionResult.allMissingInput shouldBe Success(Seq(VariableName("Signatory")))
+      case Left(ex) =>
+        fail(ex)
+    }
+  }
+
+  it should "provide the missingInput fields for external signature type" in {
+    val text =
+      """
+        |[[Signatory: ExternalSignature(serviceName:"Test")]]
+        |Test simple template
+      """.stripMargin
+
+    executeTemplate(text) match {
+      case Right(executionResult) =>
+        val Success(validationResult) = executionResult.validateExecution
+        println("identities: " + validationResult.identities)
+        println("missingIdentities: " + validationResult.missingIdentities.toString())
+        println("missingInputs: " + validationResult.missingInputs.toList.map(v => v.name).toString)
+        println("validationExpressionErrors: " + validationResult.validationExpressionErrors.toString)
+        executionResult.allMissingInput shouldBe Success(Seq(VariableName("Signatory")))
+      case Left(ex) =>
+        fail(ex)
+    }
+  }
+
 }

--- a/shared/src/test/scala/org/adridadou/openlaw/parser/OpenlawTemplateLanguageParserSpec.scala
+++ b/shared/src/test/scala/org/adridadou/openlaw/parser/OpenlawTemplateLanguageParserSpec.scala
@@ -1622,6 +1622,7 @@ here""".stripMargin
         val Success(validationResult) = executionResult.validateExecution
         validationResult.missingIdentities shouldBe Seq(VariableName("Signatory"))
         validationResult.missingInputs shouldBe Seq(VariableName("Signatory"))
+        executionResult.allMissingInput shouldBe Right(Seq(VariableName("Signatory")))
       case Left(ex) =>
         fail(ex)
     }
@@ -1639,7 +1640,7 @@ here""".stripMargin
         val Success(validationResult) = executionResult.validateExecution
         validationResult.missingIdentities shouldBe Seq(VariableName("Signatory"))
         validationResult.missingInputs shouldBe Seq(VariableName("Signatory"), VariableName("Signatory.serviceName"))
-//        executionResult.allMissingInput???
+        executionResult.allMissingInput shouldBe Right(Seq(VariableName("Signatory")))
       case Left(ex) =>
         fail(ex)
     }

--- a/shared/src/test/scala/org/adridadou/openlaw/parser/OpenlawTemplateLanguageParserSpec.scala
+++ b/shared/src/test/scala/org/adridadou/openlaw/parser/OpenlawTemplateLanguageParserSpec.scala
@@ -1640,6 +1640,7 @@ here""".stripMargin
         val Success(validationResult) = executionResult.validateExecution
         validationResult.missingIdentities shouldBe Seq(VariableName("Signatory"))
         validationResult.missingInputs shouldBe Seq(VariableName("Signatory"), VariableName("Signatory.serviceName"))
+        validationResult.validationExpressionErrors shouldBe Seq("Invalid or missing property <Signatory.serviceName>")
         executionResult.allMissingInput shouldBe Right(Seq(VariableName("Signatory"), VariableName("Signatory.serviceName")))
       case Left(ex) =>
         fail(ex)
@@ -1702,6 +1703,7 @@ here""".stripMargin
         val Success(validationResult) = executionResult.validateExecution
         validationResult.missingIdentities shouldBe Seq()
         validationResult.missingInputs shouldBe Seq(VariableName("CustomCall.serviceName"))
+        validationResult.validationExpressionErrors shouldBe Seq("Invalid or missing property <CustomCall.serviceName>")
         executionResult.allMissingInput shouldBe Right(Seq(VariableName("CustomCall.serviceName")))
       case Left(ex) =>
         fail(ex)

--- a/shared/src/test/scala/org/adridadou/openlaw/parser/OpenlawTemplateLanguageParserSpec.scala
+++ b/shared/src/test/scala/org/adridadou/openlaw/parser/OpenlawTemplateLanguageParserSpec.scala
@@ -1611,7 +1611,7 @@ here""".stripMargin
     }
   }
 
-  it should "provide the missingInput fields for identity type" in {
+  it should "provide the missing input fields for identity type" in {
     val text =
       """
         |[[Signatory: Identity]]
@@ -1619,27 +1619,27 @@ here""".stripMargin
 
     executeTemplate(text) match {
       case Right(executionResult) =>
-        executionResult.allMissingInput shouldBe Success(Seq(VariableName("Signatory")))
+        val Success(validationResult) = executionResult.validateExecution
+        validationResult.missingIdentities shouldBe Seq(VariableName("Signatory"))
+        validationResult.missingInputs shouldBe Seq(VariableName("Signatory"))
       case Left(ex) =>
         fail(ex)
     }
   }
 
-  it should "provide the missingInput fields for external signature type" in {
+  it should "provide the missing input fields for external signature type" in {
     val text =
       """
-        |[[Signatory: ExternalSignature(serviceName:"Test")]]
+        |[[Signatory: ExternalSignature(serviceName:"")]]
         |Test simple template
       """.stripMargin
 
     executeTemplate(text) match {
       case Right(executionResult) =>
         val Success(validationResult) = executionResult.validateExecution
-        println("identities: " + validationResult.identities)
-        println("missingIdentities: " + validationResult.missingIdentities.toString())
-        println("missingInputs: " + validationResult.missingInputs.toList.map(v => v.name).toString)
-        println("validationExpressionErrors: " + validationResult.validationExpressionErrors.toString)
-        executionResult.allMissingInput shouldBe Success(Seq(VariableName("Signatory")))
+        validationResult.missingIdentities shouldBe Seq(VariableName("Signatory"))
+        validationResult.missingInputs shouldBe Seq(VariableName("Signatory"), VariableName("Signatory.serviceName"))
+//        executionResult.allMissingInput???
       case Left(ex) =>
         fail(ex)
     }


### PR DESCRIPTION
It checks if the property `serviceName` from `ExternalCall` and `ExternalSignature` types are declared with a valid value. A valid value is a non empty string that matches any of the service names declared in the `externalCallStructures`.