### PR TITLE
Fixed serviceName property validation

### DIFF
--- a/shared/src/test/scala/org/adridadou/openlaw/oracles/ExternalCallOracleSpec.scala
+++ b/shared/src/test/scala/org/adridadou/openlaw/oracles/ExternalCallOracleSpec.scala
@@ -2,7 +2,7 @@ package org.adridadou.openlaw.oracles
 
 import java.time.{Clock, LocalDateTime}
 
-import org.adridadou.openlaw.parser.template.variableTypes.RequestIdentifier
+import org.adridadou.openlaw.parser.template.variableTypes.{IntegratedServiceDefinition, RequestIdentifier, ServiceName}
 import org.adridadou.openlaw.{OpenlawMap, OpenlawValue}
 import org.adridadou.openlaw.parser.template.{ActionIdentifier, OpenlawTemplateLanguageParserService, VariableName, VariableTypeDefinition}
 import org.adridadou.openlaw.result.{Failure, Success}
@@ -62,7 +62,8 @@ class ExternalCallOracleSpec extends FlatSpec with Matchers with Checkers {
 
   private val templateId = TemplateId(TestCryptoService.sha256(template))
   private val definition = ContractDefinition(UserId("hello@world.com"), templateId, Map(), TemplateParameters("param1" -> "a", "param2" -> "b"))
-  private val vm = vmProvider.create(definition, None, OpenlawSignatureOracle(TestCryptoService, serverAccount.address), Seq(oracle))
+  private val externalCallStructures = Map(ServiceName("SomeIntegratedService") -> IntegratedServiceDefinition("""[[Input:Structure(param1:Text;param2:Text)]] [[Output:Structure(result:Text)]]""").getOrThrow())
+  private val vm = vmProvider.create(definition, None, OpenlawSignatureOracle(TestCryptoService, serverAccount.address), Seq(oracle), externalCallStructures)
 
   vm(LoadTemplate(template))
 


### PR DESCRIPTION
As discussed with @adridadou we should not add the `serviceName` as a missing input in the contract validation result because it is used only for form input fields. So this PR reverts the change merged https://github.com/openlawteam/openlaw-core/pull/172 and moves the `serviceName` validation to the constructor of each type: `ExternalCall` and `ExternalSignature`. With this approach we can validate the property before the type gets instantiated. Fixed tests and tested this with web app. All good.