### PR TITLE
CI: repair shell linter

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,8 @@
 # Toolchain and dependency upgrades must be reviewed for infra
 build.sbt   @openlawteam/infra
 project/*   @openlawteam/infra
+
+# scripts for CI/CD builds
+.github/*   @openlawteam/infra
+scripts/*   @openlawteam/infra
+ci/*        @openlawteam/infra

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,12 +2,13 @@ on: push
 name: Linters on push
 
 jobs:
-
+  # we have some bash scripts used in CI, lint them with shellcheck for safety
   lint-shell:
+    name: Run shellcheck
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - name: Shellcheck Lint
-      uses: actions/bin/shellcheck@master
-      with:
-        args: scripts/*.sh ci/*.sh
+      - uses: actions/checkout@v1
+      - name: Shellcheck Lint
+        uses: azohra/shell-linter@v0.1.0
+        with:
+          path: "scripts,ci"


### PR DESCRIPTION
We apparently missed this repo in the GitHub Actions beta transition.

This also adds the CI scripts to the "automatic tag" for @openlawteam/infra in PRs.