### PR TITLE
added operator predecence for expressions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -158,7 +158,6 @@ lazy val openlawCore = crossProject(JSPlatform, JVMPlatform)
   .crossType(CrossType.Pure) // the project does not have separate sources for JVM and JS
   .in(file("shared"))
   .jvmSettings(
-    scapegoatVersion in ThisBuild := "1.3.8",
     libraryDependencies ++= Seq(
       //circe is used to serialize / deserialize json
       "io.circe"                %% "circe-core"          % circeV,

--- a/build.sbt
+++ b/build.sbt
@@ -158,6 +158,7 @@ lazy val openlawCore = crossProject(JSPlatform, JVMPlatform)
   .crossType(CrossType.Pure) // the project does not have separate sources for JVM and JS
   .in(file("shared"))
   .jvmSettings(
+    scapegoatVersion in ThisBuild := "1.3.8",
     libraryDependencies ++= Seq(
       //circe is used to serialize / deserialize json
       "io.circe"                %% "circe-core"          % circeV,

--- a/shared/src/main/scala/org/adridadou/openlaw/parser/template/Block.scala
+++ b/shared/src/main/scala/org/adridadou/openlaw/parser/template/Block.scala
@@ -32,7 +32,7 @@ final case class Block(elems:Seq[TemplatePart] = Seq()) {
   private def expressionVariables(expression: Expression):Seq[VariableDefinition] = {
     expression match {
       case variable:VariableDefinition => Seq(variable)
-      case ComparaisonExpression(expr1, expr2, _) => expressionVariables(expr1) ++ expressionVariables(expr2)
+      case ComparisonExpression(expr1, expr2, _) => expressionVariables(expr1) ++ expressionVariables(expr2)
       case EqualsExpression(expr1, expr2) => expressionVariables(expr1) ++ expressionVariables(expr2)
       case BooleanExpression(expr1, expr2, _) => expressionVariables(expr1) ++ expressionVariables(expr2)
       case BooleanUnaryExpression(expr, _) => expressionVariables(expr)

--- a/shared/src/main/scala/org/adridadou/openlaw/parser/template/ExpressionRules.scala
+++ b/shared/src/main/scala/org/adridadou/openlaw/parser/template/ExpressionRules.scala
@@ -6,12 +6,11 @@ import io.circe._
 import io.circe.generic.auto._
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import io.circe.syntax._
-import org.adridadou.openlaw.{OpenlawNativeValue, OpenlawValue}
+import org.adridadou.openlaw.OpenlawNativeValue
 import org.adridadou.openlaw.parser.template.variableTypes._
 import org.parboiled2.Rule1
 import org.adridadou.openlaw.parser.template.expressions._
-import org.adridadou.openlaw.result.{Failure, Result, Success}
-import org.adridadou.openlaw.result.Implicits.RichResult
+import org.adridadou.openlaw.result.Result
 
 import scala.reflect.ClassTag
 
@@ -20,55 +19,80 @@ import scala.reflect.ClassTag
   */
 trait ExpressionRules extends JsonRules {
 
-  def ExpressionRule: Rule1[Expression] = rule {
-      Term ~ wsNoReturn ~ zeroOrMore(operation ~ wsNoReturn ~ Term ~ wsNoReturn ~> ((op, expr) => PartialOperation(op, expr))) ~> ((left: Expression, others: Seq[PartialOperation]) => others.foldLeft(left)({
-        case (expr, op) => createOperation(expr, op).getOrThrow() // TODO: Convert this to use fail()
-      }))
-    }
-    //.recoverMerge { case failure => fail(failure.message) }
+  def ExpressionRule:Rule1[Expression] = rule {
+    BooleanTerm | Term | SubTerm | Factor
+  }
 
-  def Term:Rule1[Expression] = rule {
-    wsNoReturn ~ Factor ~ wsNoReturn ~ zeroOrMore(
-      operation ~ wsNoReturn ~ Factor ~ wsNoReturn ~> ((op, expr) => PartialOperation(op,expr))
-    ) ~> ((left:Expression, others:Seq[PartialOperation]) => others.foldLeft(left)({
-      case (expr, op) => createOperation(expr,op).getOrThrow() // TODO: Convert this to use fail()
+  def BooleanTerm: Rule1[Expression] = rule {
+    Term ~ wsNoReturn ~ zeroOrMore(BooleanPartial) ~> ((left:Expression, others:Seq[PartialOperation]) => others.foldLeft(left)({
+      case (current, PartialOperation(op, right)) => createOperation(current, op, right)
     }))
   }
 
-  private def createOperation(left:Expression, op:PartialOperation): Result[Expression] = op.op match {
-    case "+" => Success(ValueExpression(left, op.expr, Plus))
-    case "-" => Success(ValueExpression(left, op.expr, Minus))
-    case "/" => Success(ValueExpression(left, op.expr, Divide))
-    case "*" => Success(ValueExpression(left, op.expr, Multiple))
-    case "||" => Success(BooleanExpression(left, op.expr, Or))
-    case "&&" => Success(BooleanExpression(left, op.expr, And))
-    case ">" => Success(ComparaisonExpression(left, op.expr, GreaterThan))
-    case "<" => Success(ComparaisonExpression(left, op.expr, LesserThan))
-    case ">=" => Success(ComparaisonExpression(left, op.expr, GreaterOrEqual))
-    case "<=" => Success(ComparaisonExpression(left, op.expr, LesserOrEqual))
-    case "=" => Success(ComparaisonExpression(left, op.expr, Equals))
-    case _ => Failure(s"unknown operation ${op.op}")
+  def BooleanPartial: Rule1[PartialOperation] = rule {
+    booleanOperation ~ wsNoReturn ~ Term ~> ((op:String, expr:Expression) => PartialOperation(op, expr))
   }
 
-  def Factor:Rule1[Expression] = rule {constant | conditionalVariableDefinition | variableMemberInner | variableName | Parens | UnaryMinus | UnaryNot }
+  def ValuePartial: Rule1[PartialOperation] = rule {
+    valueOperation ~ wsNoReturn ~ SubTerm ~> ((op:String, expr:Expression) => PartialOperation(op, expr))
+  }
+
+  def Term: Rule1[Expression] = rule {
+    SubTerm ~ wsNoReturn ~ comparisonOperation ~ wsNoReturn ~ SubTerm ~> ((left:Expression, op:String, right: Expression) => createOperation(left, op, right))
+  }
+
+  def SubTerm: Rule1[Expression] = rule {
+    Factor ~ wsNoReturn ~ zeroOrMore(ValuePartial) ~> ((left:Expression, others:Seq[PartialOperation]) => others.foldLeft(left)({
+      case (left, PartialOperation(op, right)) => createOperation(left, op, right)
+    })) |
+    Factor
+  }
+
+  private def createOperation(left:Expression, op:String, right:Expression): Expression = op match {
+    case "+" => ValueExpression(left, right, Plus)
+    case "-" => ValueExpression(left, right, Minus)
+    case "/" => ValueExpression(left, right, Divide)
+    case "*" => ValueExpression(left, right, Multiple)
+    case "||" => BooleanExpression(left, right, Or)
+    case "&&" => BooleanExpression(left, right, And)
+    case ">" => ComparisonExpression(left, right, GreaterThan)
+    case "<" => ComparisonExpression(left, right, LesserThan)
+    case ">=" => ComparisonExpression(left, right, GreaterOrEqual)
+    case "<=" => ComparisonExpression(left, right, LesserOrEqual)
+    case "=" => ComparisonExpression(left, right, Equals)
+    case _ => throw new RuntimeException(s"unknown operation ${op}")
+  }
+
+  def  Factor:Rule1[Expression] = rule {constant | conditionalVariableDefinition | variableMemberInner | variableName | Parens | UnaryMinus | UnaryNot }
 
   def Parens:Rule1[Expression] = rule { '(' ~ wsNoReturn ~ ExpressionRule ~ wsNoReturn ~ ')' ~> ((expr:Expression) => ParensExpression(expr)) }
 
-  def UnaryMinus:Rule1[Expression] = rule { '-' ~ ExpressionRule ~> ((expr: Expression) => ValueExpression(NumberConstant(BigDecimal(-1)), expr, Multiple))}
+  def UnaryMinus:Rule1[Expression] = rule { '-' ~ wsNoReturn ~ ExpressionRule ~> ((expr: Expression) => ValueExpression(NumberConstant(BigDecimal(-1)), expr, Multiple))}
 
-  def UnaryNot:Rule1[Expression] = rule { '!' ~ ExpressionRule ~> ((expr: Expression) => BooleanUnaryExpression(expr, Not))}
+  def UnaryNot:Rule1[Expression] = rule { '!' ~ wsNoReturn ~ ExpressionRule ~> ((expr: Expression) => BooleanUnaryExpression(expr, Not))}
+
+  private def valueOperation:Rule1[String] = rule {
+    capture("+" | "-" | "/" | "*")
+  }
+
+  private def comparisonOperation:Rule1[String] = rule {
+    capture(">=" | "<=" | ">" | "<" | "=" | "||" | "&&")
+  }
+
+  private def booleanOperation:Rule1[String] = rule {
+    capture("||" | "&&" | "=")
+  }
 
   private def operation:Rule1[String] = rule {
     capture("+" | "-" | "/" | "*" | ">=" | "<=" | ">" | "<" | "=" | "||" | "&&")
   }
 
-  def variableAlias : Rule1[VariableAliasing] = rule { openS  ~ zeroOrMore(" ") ~ variableAliasingDefinition ~ zeroOrMore(" ") ~ closeS
-  }
+  def variableAlias : Rule1[VariableAliasing] = rule { openS  ~ wsNoReturn ~ variableAliasingDefinition ~ wsNoReturn ~ closeS}
 
   def varAliasKey: Rule1[VariableAliasing] = rule { &(openS) ~ variableAlias  }
 
   def variableAliasingDefinition:Rule1[VariableAliasing] = rule {
-    "@" ~ charsKeyAST ~ zeroOrMore(' ')  ~ "=" ~ zeroOrMore(' ') ~ ExpressionRule ~>
+    "@" ~ charsKeyAST ~ zeroOrMore(' ')  ~ "=" ~ wsNoReturn ~ ExpressionRule ~>
       ((aKey:String, expression:Expression) => {
         VariableAliasing(VariableName(aKey.trim), expression)
       })
@@ -109,11 +133,11 @@ trait ExpressionRules extends JsonRules {
   }
 
   def variable : Rule1[VariableDefinition] = rule {
-    openS ~ zeroOrMore(" ") ~ variableDefinition ~ zeroOrMore(" ") ~ closeS
+    openS ~ wsNoReturn ~ variableDefinition ~ wsNoReturn ~ closeS
   }
 
   def variableMember: Rule1[VariableMember] = rule {
-    openS ~ zeroOrMore(" ") ~ charsKeyAST ~ oneOrMore("." ~ charsKeyAST) ~ optional( ws ~ "|" ~ formatterDefinition) ~ closeS ~>((name:String, member:Seq[String], formatter:Option[FormatterDefinition]) => VariableMember(VariableName(name), member.map(_.trim), formatter))
+    openS ~ wsNoReturn ~ charsKeyAST ~ oneOrMore("." ~ charsKeyAST) ~ optional( ws ~ "|" ~ formatterDefinition) ~ closeS ~>((name:String, member:Seq[String], formatter:Option[FormatterDefinition]) => VariableMember(VariableName(name), member.map(_.trim), formatter))
   }
 
   def variableMemberInner: Rule1[VariableMember] = rule {
@@ -156,13 +180,14 @@ trait ExpressionRules extends JsonRules {
   }
 
   def MappingRule:Rule1[(VariableName, Expression)] = rule {
-    ws ~ charsKeyAST ~ ws ~ "->" ~ ws ~ ExpressionRule ~ ws ~> ((name:String, expr:Expression) => (VariableName(name.trim), expr))
+    ws ~ charsKeyAST ~ wsNoReturn ~ "->" ~ wsNoReturn ~ ExpressionRule ~ wsNoReturn ~> ((name:String, expr:Expression) => (VariableName(name.trim), expr))
   }
 
   def constant:Rule1[Expression] = rule {
+    ws ~ (
     numberDefinition ~> ((constant:BigDecimal) => NumberConstant(constant)) |
     stringDefinition ~> ((constant:String) => StringConstant(constant)) |
-    jsonDefinition ~> ((json:Json) => JsonConstant(json.noSpaces))
+    jsonDefinition ~> ((json:Json) => JsonConstant(json.noSpaces)))
   }
 }
 sealed trait Operation

--- a/shared/src/main/scala/org/adridadou/openlaw/parser/template/ExpressionRules.scala
+++ b/shared/src/main/scala/org/adridadou/openlaw/parser/template/ExpressionRules.scala
@@ -30,11 +30,11 @@ trait ExpressionRules extends JsonRules {
   }
 
   def BooleanPartial: Rule1[PartialOperation] = rule {
-    booleanOperation ~ wsNoReturn ~ Term ~> ((op:String, expr:Expression) => PartialOperation(op, expr))
+    booleanOperation ~ wsNoReturn ~ (Term | Factor) ~> ((op:String, expr:Expression) => PartialOperation(op, expr))
   }
 
   def ValuePartial: Rule1[PartialOperation] = rule {
-    valueOperation ~ wsNoReturn ~ SubTerm ~> ((op:String, expr:Expression) => PartialOperation(op, expr))
+    valueOperation ~ wsNoReturn ~ (SubTerm | Factor) ~> ((op:String, expr:Expression) => PartialOperation(op, expr))
   }
 
   def Term: Rule1[Expression] = rule {

--- a/shared/src/main/scala/org/adridadou/openlaw/parser/template/JsonRules.scala
+++ b/shared/src/main/scala/org/adridadou/openlaw/parser/template/JsonRules.scala
@@ -30,12 +30,10 @@ trait JsonRules extends GlobalRules with StringBuilding{
 
   // the root rule
   def jsonDefinition = rule {
-    WhiteSpace ~ (
       JsonObject |
       JsonArray |
       JsonTrue |
       JsonFalse
-      )
   }
 
   def JsonObject: Rule1[Json] = rule {

--- a/shared/src/main/scala/org/adridadou/openlaw/parser/template/expressions/BooleanExpression.scala
+++ b/shared/src/main/scala/org/adridadou/openlaw/parser/template/expressions/BooleanExpression.scala
@@ -73,7 +73,7 @@ final case class BooleanExpression(left:Expression, right:Expression, op:Boolean
       }
     }
 
-  override def toString: String = left.toString + op.toString + right.toString
+  override def toString: String = s"$left $op $right"
 
   override def missingInput(executionResult: TemplateExecutionResult): Result[Seq[VariableName]] = for {
       leftMissing <- left.missingInput(executionResult)

--- a/shared/src/main/scala/org/adridadou/openlaw/parser/template/expressions/ComparisonExpression.scala
+++ b/shared/src/main/scala/org/adridadou/openlaw/parser/template/expressions/ComparisonExpression.scala
@@ -6,7 +6,7 @@ import cats.implicits._
 import org.adridadou.openlaw.OpenlawBoolean
 import org.adridadou.openlaw.result.{Failure, Result, Success}
 
-final case class ComparaisonExpression(left:Expression, right:Expression, op:Operation) extends BinaryExpression {
+final case class ComparisonExpression(left:Expression, right:Expression, op:Operation) extends BinaryExpression {
 
   override def evaluate(executionResult: TemplateExecutionResult): Result[Option[OpenlawBoolean]] =
     (for {

--- a/shared/src/main/scala/org/adridadou/openlaw/parser/template/expressions/ValueExpression.scala
+++ b/shared/src/main/scala/org/adridadou/openlaw/parser/template/expressions/ValueExpression.scala
@@ -43,5 +43,5 @@ final case class ValueExpression(left:Expression, right:Expression, operation:Va
       }
     } yield result
 
-  override def toString:String = left.toString + operation.toString + right.toString
+  override def toString:String = s"$left $operation $right"
 }

--- a/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/LargeTextType.scala
+++ b/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/LargeTextType.scala
@@ -17,7 +17,7 @@ case object LargeTextType extends VariableType("LargeText") {
 
   override def divide(optLeft: Option[OpenlawValue], optRight: Option[OpenlawValue], executionResult: TemplateExecutionResult): Result[Option[OpenlawValue]] =
     combineConverted[OpenlawString, OpenlawValue](optLeft, optRight) {
-      case (left, right) => Success(TemplatePath(Seq(left, right)))
+      case (left, right) => Success(TemplatePath(List(left, right)))
     }
 
   override def operationWith(rightType: VariableType, operation: ValueOperation): VariableType = operation match {

--- a/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/TemplateType.scala
+++ b/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/TemplateType.scala
@@ -17,8 +17,8 @@ final case class TemplateDefinition(name:TemplateSourceIdentifier, mapping:Map[V
 
 final case class TemplateSourceIdentifier(name:TemplateTitle)
 
-final case class TemplatePath(path:Seq[String] = Seq()) extends OpenlawNativeValue {
-  def innerFile(name:String):TemplatePath = TemplatePath(path ++ Seq(name))
+final case class TemplatePath(path:List[String] = Nil) extends OpenlawNativeValue {
+  def innerFile(name:String):TemplatePath = TemplatePath(path ++ List(name))
 }
 
 case object TemplatePathType extends VariableType("TemplateType") with NoShowInForm {
@@ -96,10 +96,10 @@ case object TemplateType extends VariableType("Template") with NoShowInForm {
           case p: TemplatePath =>
             Success(Some(p))
           case p: OpenlawString =>
-            Success(Some(TemplatePath(Seq(p.underlying))))
+            Success(Some(TemplatePath(List(p.underlying))))
           case other =>
             Failure(s"parameter 'path' should be a path but instead was ${other.getClass.getSimpleName}")
-        }).getOrElse(Right(None))
+        }).getOrElse(Success(None))
       }
     case Some(other) =>
       Failure(s"parameter 'path' should be a single value, not ${other.getClass.getSimpleName}")

--- a/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/TextType.scala
+++ b/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/TextType.scala
@@ -14,10 +14,19 @@ case object TextType extends VariableType("Text") {
       case (left, right) => Success(left + right)
     }
 
-  override def divide(optLeft: Option[OpenlawValue], optRight: Option[OpenlawValue], executionResult: TemplateExecutionResult): Result[Option[TemplatePath]] =
-    combineConverted[OpenlawString, TemplatePath](optLeft, optRight) {
-      case (left, right) => Success(TemplatePath(Seq(left, right)))
+  override def divide(optLeft: Option[OpenlawValue], optRight: Option[OpenlawValue], executionResult: TemplateExecutionResult): Result[Option[TemplatePath]] = {
+    optRight match {
+      case Some(_:TemplatePath) =>
+        combineConverted[OpenlawString, TemplatePath, TemplatePath](optLeft, optRight) {
+          case (left, right) => Success(TemplatePath(left :: right.path))
+        }
+      case _ =>
+        combineConverted[OpenlawString, TemplatePath](optLeft, optRight) {
+          case (left, right) => Success(TemplatePath(List(left, right)))
+        }
     }
+
+  }
 
   override def operationWith(rightType: VariableType, operation: ValueOperation): VariableType = operation match {
     case Divide =>

--- a/shared/src/test/scala/org/adridadou/openlaw/parser/ExpressionParserSpec.scala
+++ b/shared/src/test/scala/org/adridadou/openlaw/parser/ExpressionParserSpec.scala
@@ -1,6 +1,8 @@
 package org.adridadou.openlaw.parser
 
 import org.adridadou.openlaw.parser.template._
+import org.adridadou.openlaw.parser.template.expressions.{BooleanExpression, ComparisonExpression}
+import org.adridadou.openlaw.result.{Failure, Success}
 import org.scalatest._
 
 /**
@@ -11,29 +13,29 @@ class ExpressionParserSpec  extends FlatSpec with Matchers {
   private val service = new ExpressionParserService()
 
   it should "parse simple expression" in {
-    val text = "variable 1+23"
+    val text = "variable 1 + 23"
 
     service.parseExpression(text) match {
-       case Right(result) => result.toString shouldBe text
-       case Left(error) => fail(error.e)
+       case Success(result) => result.toString shouldBe text
+       case Failure(_, message) => fail(message)
     }
   }
 
   it should "parse simple string expression" in {
-    val text = """variable 1+"hello world""""
+    val text = """variable 1 + "hello world""""
 
     service.parseExpression(text) match {
-      case Right(result) => result.toString shouldBe text
-      case Left(error) => fail(error.e)
+      case Success(result) => result.toString shouldBe text
+      case Failure(_, message) => fail(message)
     }
   }
 
   it should "parse simple expression 2" in {
-    val text = "23+variable 1"
+    val text = "23 + variable 1"
 
     service.parseExpression(text) match {
-      case Right(result) => result.toString shouldBe text
-      case Left(error) => fail(error.e)
+      case Success(result) => result.toString shouldBe text
+      case Failure(_, message) => fail(message)
     }
   }
 
@@ -41,17 +43,56 @@ class ExpressionParserSpec  extends FlatSpec with Matchers {
     val text = """{"hello":"world"}"""
 
     service.parseExpression(text) match {
-      case Right(result) => result.toString shouldBe text
-      case Left(error) => fail(error.e)
+      case Success(result) => result.toString shouldBe text
+      case Failure(_, message) => fail(message)
     }
   }
 
   it should "parse with parenthesis too" in {
-    val text = """(var 1 > var 2)&&(var 3 < var 1)"""
+    val text = """(var 1 > var 2) && (var 3 < var 1)"""
 
     service.parseExpression(text) match {
-      case Right(result) => result.toString shouldBe text
-      case Left(error) => fail(error.e)
+      case Success(result) => result.toString shouldBe text
+      case Failure(_, message) => fail(message)
+    }
+  }
+
+  it should "parse more elements" in {
+    val text = """var 1 + var 2 - 34 > var 1 - var2 && var 1 = 34"""
+
+    service.parseExpression(text) match {
+      case Success(result) => result.toString shouldBe text
+      case Failure(_, message) => fail(message)
+    }
+  }
+
+  it should "parse boolean with only variables" in {
+    val text = """var 1 && var 2"""
+
+    service.parseExpression(text) match {
+      case Success(result:BooleanExpression) =>
+        result.toString shouldBe text
+        result.op shouldBe And
+      case Failure(_, message) => fail(message)
+    }
+  }
+
+  it should "parse the expression correctly" in {
+    val text = "contract = signed && Variable 2 > 10"
+
+    service.parseExpression(text) match {
+      case Success(BooleanExpression(left, right, boolOp)) =>
+        left match {
+          case ComparisonExpression(contract, signed, op) =>
+
+        }
+        succeed
+      case Success(ComparisonExpression(left, right, op)) =>
+        println(text)
+        fail(s"left:${left}, leftType ${left.getClass.getSimpleName}, right:${right}, rightType ${right.getClass.getSimpleName} op:${op}")
+      case Success(other) =>
+        fail(s"expression should be a boolean expression, instead it is ${other.getClass.getSimpleName} ${other}")
+      case Failure(_, message) => fail(message)
     }
   }
 }

--- a/shared/src/test/scala/org/adridadou/openlaw/parser/ExpressionParserSpec.scala
+++ b/shared/src/test/scala/org/adridadou/openlaw/parser/ExpressionParserSpec.scala
@@ -1,7 +1,7 @@
 package org.adridadou.openlaw.parser
 
 import org.adridadou.openlaw.parser.template._
-import org.adridadou.openlaw.parser.template.expressions.{BooleanExpression, ComparisonExpression}
+import org.adridadou.openlaw.parser.template.expressions.{BooleanExpression, ComparisonExpression, ParensExpression}
 import org.adridadou.openlaw.result.{Failure, Success}
 import org.scalatest._
 
@@ -77,19 +77,25 @@ class ExpressionParserSpec  extends FlatSpec with Matchers {
     }
   }
 
-  it should "parse the expression correctly" in {
+  it should "use operator precedence to parse the expression" in {
     val text = "contract = signed && Variable 2 > 10"
 
     service.parseExpression(text) match {
-      case Success(BooleanExpression(left, right, boolOp)) =>
-        left match {
-          case ComparisonExpression(contract, signed, op) =>
-
-        }
-        succeed
+      case Success(BooleanExpression(_:ComparisonExpression, _:ComparisonExpression, And)) =>
       case Success(ComparisonExpression(left, right, op)) =>
         println(text)
         fail(s"left:${left}, leftType ${left.getClass.getSimpleName}, right:${right}, rightType ${right.getClass.getSimpleName} op:${op}")
+      case Success(other) =>
+        fail(s"expression should be a boolean expression, instead it is ${other.getClass.getSimpleName} ${other}")
+      case Failure(_, message) => fail(message)
+    }
+  }
+
+  it should "parse that correctly" in {
+    val text = "fill in the draft.state = \"done\" && (Variable 2 > 10)"
+
+    service.parseExpression(text) match {
+      case Success(BooleanExpression(_:ComparisonExpression, ParensExpression(_:ComparisonExpression), And)) =>
       case Success(other) =>
         fail(s"expression should be a boolean expression, instead it is ${other.getClass.getSimpleName} ${other}")
       case Failure(_, message) => fail(message)

--- a/shared/src/test/scala/org/adridadou/openlaw/parser/ExpressionParserSpec.scala
+++ b/shared/src/test/scala/org/adridadou/openlaw/parser/ExpressionParserSpec.scala
@@ -84,7 +84,7 @@ class ExpressionParserSpec  extends FlatSpec with Matchers {
       case Success(BooleanExpression(_:ComparisonExpression, _:ComparisonExpression, And)) =>
       case Success(ComparisonExpression(left, right, op)) =>
         println(text)
-        fail(s"left:${left}, leftType ${left.getClass.getSimpleName}, right:${right}, rightType ${right.getClass.getSimpleName} op:${op}")
+        fail(s"left:$left, leftType ${left.getClass.getSimpleName}, right:$right, rightType ${right.getClass.getSimpleName} op:$op")
       case Success(other) =>
         fail(s"expression should be a boolean expression, instead it is ${other.getClass.getSimpleName} ${other}")
       case Failure(_, message) => fail(message)

--- a/shared/src/test/scala/org/adridadou/openlaw/parser/OpenlawTemplateLanguageParserSpec.scala
+++ b/shared/src/test/scala/org/adridadou/openlaw/parser/OpenlawTemplateLanguageParserSpec.scala
@@ -1379,7 +1379,7 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
     structureAgreement(text) match {
       case Right(_) =>
         fail("should fail")
-      case Left(ex) => ex.message shouldBe "Conditional expression number+401 is of type NumberType instead of YesNo"
+      case Left(ex) => ex.message shouldBe "Conditional expression number + 401 is of type NumberType instead of YesNo"
     }
   }
 

--- a/shared/src/test/scala/org/adridadou/openlaw/vm/OpenlawExecutionEngineSpec.scala
+++ b/shared/src/test/scala/org/adridadou/openlaw/vm/OpenlawExecutionEngineSpec.scala
@@ -403,10 +403,11 @@ class OpenlawExecutionEngineSpec extends FlatSpec with Matchers {
     val subTemplate = compile("[[other var]]")
 
     engine.execute(mainTemplate, TemplateParameters("var" -> "Hello"), Map(TemplateSourceIdentifier(TemplateTitle("template")) -> subTemplate)) match {
-      case Right(result) =>
+      case Success(result) =>
         result.agreements.head.directory.path shouldBe Seq("Hello", "template", "me")
-      case Left(ex) =>
-        fail(ex)
+      case Failure(ex, message) =>
+        ex.printStackTrace()
+        fail(message)
     }
   }
 
@@ -741,7 +742,7 @@ class OpenlawExecutionEngineSpec extends FlatSpec with Matchers {
       case Right(_) =>
         fail("should fail")
       case Left(ex) =>
-        ex.message shouldBe "error while evaluating the expression 'Var 1/Var 2': division by zero!"
+        ex.message shouldBe "error while evaluating the expression 'Var 1 / Var 2': division by zero!"
     }
   }
 
@@ -758,7 +759,7 @@ class OpenlawExecutionEngineSpec extends FlatSpec with Matchers {
     engine.execute(template, TemplateParameters("Var 1" -> "5", "Var 2" -> "5"), Map()) match {
       case Right(_) => fail("should fail")
       case Left(ex) =>
-        ex.message shouldBe "error while evaluating the expression '(Var 1+Var 2)/(Var 1-Var 2)': division by zero!"
+        ex.message shouldBe "error while evaluating the expression '(Var 1 + Var 2) / (Var 1 - Var 2)': division by zero!"
     }
   }
 
@@ -1746,7 +1747,7 @@ class OpenlawExecutionEngineSpec extends FlatSpec with Matchers {
       case Right(_) =>
         fail("should fail when dividing by zero")
       case Left(ex) =>
-        ex.message shouldBe "error while evaluating the expression 'period/divisor': division by zero!"
+        ex.message shouldBe "error while evaluating the expression 'period / divisor': division by zero!"
     }
 
     engine.execute(template, TemplateParameters(
@@ -1755,7 +1756,7 @@ class OpenlawExecutionEngineSpec extends FlatSpec with Matchers {
       case Right(_) =>
         fail("should fail when dividing a period containing a month")
       case Left(ex) =>
-        ex.message shouldBe "error while evaluating the expression 'period/divisor': cannot divide months"
+        ex.message shouldBe "error while evaluating the expression 'period / divisor': cannot divide months"
     }
   }
 


### PR DESCRIPTION
The issue:
Because we didn't have operator precedence before, an expression such as "var 1 + var 2 > 34 && var 1 = 34" was not working since it resulted to the expression (var 1 + var2 > 34 && var1) = 34 which is not correct

This change uses operator precedence to fix that. This means, that the expression is now parsed to
(((var 1 + var 2) > 34) && (var 1 = 34))

On top of that, some cleanup has been done:
- Left / Right -> Success / Failure
- toString cleanup for expressions
- Comparaison -> Comparison (it was the french spelling)
- Seq -> List

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openlawteam/openlaw-core/206)
<!-- Reviewable:end -->
