### PR TITLE
update Metals specific gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ owasp/
 # Metals specific (Scala language server https://scalameta.org/metals/)
 .metals/
 .bloop/
+project/metals.sbt


### PR DESCRIPTION
I've been using Metals Scala language server tool for Visual Studio Code. This adds one more generated file related to that to the `.gitignore`.

From their docs: https://scalameta.org/metals/docs/editors/vscode.html#gitignore-projectmetalssbt-metals-and-bloop