### PR TITLE
Fix type resolution in sub execution

### DIFF
--- a/shared/src/main/scala/org/adridadou/openlaw/parser/template/VariableDefinition.scala
+++ b/shared/src/main/scala/org/adridadou/openlaw/parser/template/VariableDefinition.scala
@@ -167,9 +167,10 @@ final case class VariableDefinition(name: VariableName, variableTypeDefinition:O
   def isAnonymous: Boolean = name.isAnonymous
 
   def varType(executionResult: TemplateExecutionResult):VariableType =
-    variableTypeDefinition
-      .flatMap(typeDefinition => (executionResult :: executionResult.subExecutions.values.toList).flatMap(_.findVariableType(typeDefinition)).headOption)
-      .getOrElse(TextType)
+    (for {
+      typeDefinition <- variableTypeDefinition
+      variableType <- executionResult.findVariableType(typeDefinition)
+    } yield variableType).getOrElse(TextType)
 
   def verifyConstructor(executionResult: TemplateExecutionResult): Result[Option[Any]] = {
     implicit val eqCls:Eq[Class[_]] = Eq.fromUniversalEquals

--- a/shared/src/main/scala/org/adridadou/openlaw/parser/template/VariableDefinition.scala
+++ b/shared/src/main/scala/org/adridadou/openlaw/parser/template/VariableDefinition.scala
@@ -166,8 +166,10 @@ final case class VariableDefinition(name: VariableName, variableTypeDefinition:O
 
   def isAnonymous: Boolean = name.isAnonymous
 
-  def varType(executionResult: TemplateExecutionResult):VariableType = variableTypeDefinition
-    .flatMap(typeDefinition => executionResult.findVariableType(typeDefinition)).getOrElse(TextType)
+  def varType(executionResult: TemplateExecutionResult):VariableType =
+    variableTypeDefinition
+      .flatMap(typeDefinition => (executionResult :: executionResult.subExecutions.values.toList).flatMap(_.findVariableType(typeDefinition)).headOption)
+      .getOrElse(TextType)
 
   def verifyConstructor(executionResult: TemplateExecutionResult): Result[Option[Any]] = {
     implicit val eqCls:Eq[Class[_]] = Eq.fromUniversalEquals

--- a/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/EthAddressType.scala
+++ b/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/EthAddressType.scala
@@ -73,7 +73,7 @@ object EthereumAddress {
   def apply(a: String): Result[EthereumAddress] = Option(a) match {
     case None => empty
     case Some(address) if address.startsWith("0x") => apply(address.substring(2))
-    case Some(address) if address.length =!= 40 => Failure("the address string should be 40 or 42 with '0x' prefix")
+    case Some(address) if address.length =!= 40 => Failure(s"the address string should be 40 or 42 with '0x' prefix. value(${address})")
     case Some(address) => apply(hex2bytes(address))
   }
 

--- a/shared/src/test/scala/org/adridadou/openlaw/vm/OpenlawExecutionEngineSpec.scala
+++ b/shared/src/test/scala/org/adridadou/openlaw/vm/OpenlawExecutionEngineSpec.scala
@@ -784,7 +784,6 @@ class OpenlawExecutionEngineSpec extends FlatSpec with Matchers {
   }
 
   def getCollection(variable:VariableDefinition, executionResult: TemplateExecutionResult, value:String):CollectionValue = {
-    println(variable.variableTypeDefinition)
     variable.varType(executionResult) match {
       case collectionType:CollectionType =>
         if(value.isEmpty) {

--- a/shared/src/test/scala/org/adridadou/openlaw/vm/OpenlawExecutionEngineSpec.scala
+++ b/shared/src/test/scala/org/adridadou/openlaw/vm/OpenlawExecutionEngineSpec.scala
@@ -728,6 +728,20 @@ class OpenlawExecutionEngineSpec extends FlatSpec with Matchers {
     }
   }
 
+  it should "look at sub execution results for variable type" in {
+    val mainTemplate = compile("""[[c:Clause("clause")]]""")
+    val clauseTemplate = compile(
+      """[[my variable:Number]]""".stripMargin)
+
+    engine.execute(mainTemplate, TemplateParameters(), Map(TemplateSourceIdentifier(TemplateTitle("clause")) -> clauseTemplate,TemplateSourceIdentifier(TemplateTitle("clause")) -> clauseTemplate)) match {
+      case Right(result) =>
+        val Some(variable) = result.getVariable("my variable")
+        variable.varType(result) shouldBe NumberType
+      case Left(ex) =>
+        fail(ex.message, ex)
+    }
+  }
+
   it should "fail if it makes a divide by zero error" in {
     val template =
       compile("""


### PR DESCRIPTION
It seems like when the parameter is not found, then the type returned is Text instead of ParameterType<Text>

This made issues in Collection definition.

This shows another issue that I need to look at but that's still an issue we need fixing

I'm not necessarily super happy with this solution (see #210 ) but it's clearly an improvement
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openlawteam/openlaw-core/209)
<!-- Reviewable:end -->
