### PR TITLE
add triple quotes string constant

### DIFF
--- a/shared/src/main/scala/org/adridadou/openlaw/parser/template/GlobalRules.scala
+++ b/shared/src/main/scala/org/adridadou/openlaw/parser/template/GlobalRules.scala
@@ -74,6 +74,7 @@ trait GlobalRules extends Parser {
   def charsKeyAST: Rule1[String] = rule { ws ~ capture(firstKeyChar ~ zeroOrMore(keyChar)) }
 
   def stringDefinition:Rule1[String] = rule {
+    stringDefinition("\"\"\"") |
     stringDefinition("\"") |
     stringDefinition("“","”")  |
     stringDefinition("'")

--- a/shared/src/test/scala/org/adridadou/openlaw/parser/ExpressionParserSpec.scala
+++ b/shared/src/test/scala/org/adridadou/openlaw/parser/ExpressionParserSpec.scala
@@ -83,7 +83,6 @@ class ExpressionParserSpec  extends FlatSpec with Matchers {
     service.parseExpression(text) match {
       case Success(BooleanExpression(_:ComparisonExpression, _:ComparisonExpression, And)) =>
       case Success(ComparisonExpression(left, right, op)) =>
-        println(text)
         fail(s"left:$left, leftType ${left.getClass.getSimpleName}, right:$right, rightType ${right.getClass.getSimpleName} op:$op")
       case Success(other) =>
         fail(s"expression should be a boolean expression, instead it is ${other.getClass.getSimpleName} ${other}")
@@ -142,6 +141,25 @@ class ExpressionParserSpec  extends FlatSpec with Matchers {
 
     service.parseExpression(text) match {
       case Success(BooleanConstant(true,_)) =>
+      case Success(other) =>
+        fail(s"expression should be a boolean expression, instead it is ${other.getClass.getSimpleName} ${other}")
+      case Failure(_, message) => fail(message)
+    }
+  }
+
+  it should "be able to parse triple quote string constant" in {
+    val tripleQuote = "\"\"\""
+    val text =
+      """
+        |this is a test
+        |"hello world"
+        |all that works
+        |""".stripMargin
+
+    service.parseExpression(tripleQuote + text + tripleQuote) match {
+      case Success(StringConstant(cText,_)) =>
+        println(cText)
+        text shouldBe cText
       case Success(other) =>
         fail(s"expression should be a boolean expression, instead it is ${other.getClass.getSimpleName} ${other}")
       case Failure(_, message) => fail(message)

--- a/shared/src/test/scala/org/adridadou/openlaw/vm/OpenlawExecutionEngineSpec.scala
+++ b/shared/src/test/scala/org/adridadou/openlaw/vm/OpenlawExecutionEngineSpec.scala
@@ -1891,7 +1891,6 @@ class OpenlawExecutionEngineSpec extends FlatSpec with Matchers {
     result2.state shouldBe ExecutionFinished
 
     val text2 = parser.forReview(result2.agreements.head,ParagraphEdits())
-    println(text2)
     text2 shouldBe """<p class="no-section"> something else<br /></p>"""
   }
 


### PR DESCRIPTION
This is similar to what Scala does to be able to define richer String constants.

The rule is:
"""
put here what ever you want bla bla bla 
even "string definition"
"""

This is useful if we want to be able to define templates within the langue (pass as arguments)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openlawteam/openlaw-core/213)
<!-- Reviewable:end -->
