### PR TITLE
Fix collection.map to work with every type

### DIFF
--- a/shared/src/main/scala/org/adridadou/openlaw/parser/template/ExpressionRules.scala
+++ b/shared/src/main/scala/org/adridadou/openlaw/parser/template/ExpressionRules.scala
@@ -305,7 +305,7 @@ final case class OneValueParameter(expr:Expression) extends Parameter {
 }
 final case class ListParameter(exprs:List[Expression]) extends Parameter {
   override def variables(executionResult: TemplateExecutionResult): Result[List[VariableName]] =
-    exprs.toList.map(_.variables(executionResult)).sequence.map(_.flatten.distinct)
+    exprs.map(_.variables(executionResult)).sequence.map(_.flatten.distinct)
 
   override def serialize: Json = this.asJson
 }

--- a/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/CollectionType.scala
+++ b/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/CollectionType.scala
@@ -81,13 +81,11 @@ final case class CollectionType(typeParameter:VariableType) extends VariableType
     }
   }
 
-  private def applyMap(value:OpenlawValue, func:OLFunction, executionResult: TemplateExecutionResult):Result[Option[OpenlawValue]] = {
-    println(s"parameter type ${func.parameter.varType(executionResult)}")
+  private def applyMap(value:OpenlawValue, func:OLFunction, executionResult: TemplateExecutionResult):Result[Option[OpenlawValue]] =
     for {
       ier <- executionResult.withVariable(func.parameter.name, value, typeParameter)
       newValue <- func.expression.evaluate(ier)
     } yield newValue
-  }
 
   override def keysType(keys: List[VariableMemberKey], expression: Expression, executionResult: TemplateExecutionResult): Result[VariableType] =
     keys match {

--- a/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/CollectionType.scala
+++ b/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/CollectionType.scala
@@ -91,8 +91,12 @@ final case class CollectionType(typeParameter:VariableType) extends VariableType
     keys match {
       case Nil =>
         Success(AbstractStructureType)
-      case VariableMemberKey(Right(OLFunctionCall(VariableName("map"), _)))::Nil =>
-        Success(AbstractFunctionType)
+      case VariableMemberKey(Right(OLFunctionCall(VariableName("map"), func:OLFunction)))::Nil =>
+        for {
+          ier <- executionResult.withVariable(func.parameter.name, None, typeParameter)
+          kType <- func.expression.expressionType(ier).map(CollectionType)
+        } yield kType
+
       case _ =>
         Failure(s"property '${keys.mkString(".")}' could not be resolved in collection type")
     }

--- a/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/VariableType.scala
+++ b/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/VariableType.scala
@@ -222,7 +222,7 @@ abstract class VariableType(val name: String) {
     keys.headOption.map(_ => Failure(s"The variable $variableName of type $name has no properties")).getOrElse(Success(()))
 
   def keysType(keys: List[VariableMemberKey], expression: Expression, executionResult: TemplateExecutionResult):Result[VariableType] = if(keys.nonEmpty) {
-    Failure(s"the type $name has no properties")
+    Failure(s"the type $name has no properties (tried to access ${keys.mkString(".")})")
   } else {
     Success(thisType)
   }

--- a/shared/src/test/scala/org/adridadou/openlaw/vm/OpenlawExecutionEngineSpec.scala
+++ b/shared/src/test/scala/org/adridadou/openlaw/vm/OpenlawExecutionEngineSpec.scala
@@ -1940,7 +1940,50 @@ class OpenlawExecutionEngineSpec extends FlatSpec with Matchers {
 
     val Success(newCollection) = result.evaluate[CollectionValue]("new collection")
     newCollection.values shouldBe Map(0 -> "one world", 1 -> "two world", 2 -> "blabla world")
-    newCollection
+  }
+
+  it should "be able to use 'map' for collections with numbers" in {
+    val template =
+      compile(
+        """[[collection:Collection<Number>]]
+          |
+          |[[@new collection = collection.map(elem => elem + 10)]]""".stripMargin)
+
+    val collectionType = CollectionType(NumberType)
+
+    val collectionStr = collectionType.internalFormat(CollectionValue(size = 3, values = Map(0 -> BigDecimal("1"), 1 -> BigDecimal("3"), 2 -> BigDecimal("45")), collectionType = collectionType)).getOrThrow()
+    val Success(result) = engine.execute(template, TemplateParameters("collection" -> collectionStr))
+    result.state shouldBe ExecutionFinished
+
+    val newCollection = result.evaluate[CollectionValue]("new collection").getOrThrow()
+    newCollection.values shouldBe Map(0 -> BigDecimal("11"), 1 -> BigDecimal("13"), 2 -> BigDecimal("55"))
+  }
+
+  it should "be able to use 'map' for collections with structure where we extract a field" in {
+    val template =
+      compile(
+        """
+          |[[My Structure: Structure(
+          |name:Text;
+          |age:Number
+          |)]]
+          |[[collection:Collection<My Structure>]]
+          |
+          |[[@new collection = collection.map(elem => elem.age)]]""".stripMargin)
+
+    val Success(resultToGetType) = engine.execute(template, TemplateParameters())
+    val Some(structureType) = resultToGetType.findVariableType(VariableTypeDefinition("My Structure"))
+    val collectionType = CollectionType(structureType)
+
+    val value1:Map[VariableName, OpenlawValue] = Map[VariableName, OpenlawValue](VariableName("name") -> OpenlawString("David Roon"), VariableName("age") -> OpenlawBigDecimal(BigDecimal(37)))
+    val value2:Map[VariableName, OpenlawValue] = Map[VariableName, OpenlawValue](VariableName("name") -> OpenlawString("David UIhiuh"), VariableName("age") -> OpenlawBigDecimal(BigDecimal(47)))
+
+    val collectionStr = collectionType.internalFormat(CollectionValue(size = 2, values = Map(0 -> value1, 1 -> value2), collectionType = collectionType)).getOrThrow()
+    val Success(result) = engine.execute(template, TemplateParameters("collection" -> collectionStr))
+    result.state shouldBe ExecutionFinished
+
+    val newCollection = result.evaluate[CollectionValue]("new collection").getOrThrow()
+    newCollection.values shouldBe Map(0 -> BigDecimal("37"), 1 -> BigDecimal("47"))
   }
 
   it should "be able to use regex to match patterns" in {

--- a/shared/src/test/scala/org/adridadou/openlaw/vm/OpenlawExecutionEngineSpec.scala
+++ b/shared/src/test/scala/org/adridadou/openlaw/vm/OpenlawExecutionEngineSpec.scala
@@ -1984,6 +1984,10 @@ class OpenlawExecutionEngineSpec extends FlatSpec with Matchers {
 
     val newCollection = result.evaluate[CollectionValue]("new collection").getOrThrow()
     newCollection.values shouldBe Map(0 -> BigDecimal("37"), 1 -> BigDecimal("47"))
+    val Success(expr) = result.parseExpression("new collection")
+    expr.expressionType(result).getOrThrow()
+    val Success(exprType:CollectionType) = expr.expressionType(result)
+    exprType.typeParameter shouldBe NumberType
   }
 
   it should "be able to use regex to match patterns" in {


### PR DESCRIPTION
This fixes the `collection.map` function to handle not only String types, but any other parameter type.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openlawteam/openlaw-core/217)
<!-- Reviewable:end -->
