### PR TITLE
New variable type added: ExternalStorage

### DIFF
--- a/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/ExternalStorageType.scala
+++ b/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/ExternalStorageType.scala
@@ -1,0 +1,109 @@
+package org.adridadou.openlaw.parser.template.variableTypes
+
+import io.circe.syntax._
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+import io.circe._
+import org.adridadou.openlaw.result.Implicits._
+import org.adridadou.openlaw
+import org.adridadou.openlaw.{OpenlawNativeValue, OpenlawString, OpenlawValue}
+import org.adridadou.openlaw.parser.template.{
+  Parameter,
+  Parameters,
+  TemplateExecutionResult,
+}
+import org.adridadou.openlaw.result.{
+  Failure,
+  FailureException,
+  Result,
+  Success,
+}
+import cats.implicits._
+import io.circe.parser.decode
+import org.adridadou.openlaw.parser.template.expressions.Expression
+
+final case class ExternalStorage(serviceName: Expression,
+                                 fileType: Expression,
+                                 filePath: Expression)
+    extends OpenlawNativeValue
+
+object ExternalStorage {
+  implicit val externalCallEnc: Encoder[ExternalStorage] = deriveEncoder
+  implicit val externalCallDec: Decoder[ExternalStorage] = deriveDecoder
+}
+
+object ExternalStorageType extends VariableType("ExternalStorage") {
+
+  override def getTypeClass: Class[_ <: openlaw.OpenlawValue] =
+    classOf[ExternalStorage]
+
+  override def construct(
+    constructorParams: Parameter,
+    executionResult: TemplateExecutionResult
+  ): Result[Option[OpenlawValue]] = {
+    constructorParams match {
+      case Parameters(v) =>
+        val values = v.toMap
+        for {
+          serviceNameExp <- getExpression(
+            values,
+            "serviceName",
+            "service",
+            "name",
+            "storage"
+          )
+          fileTypeExp <- getParameter(values, "fileType")
+            .map(getExpression)
+            .sequence
+          filePathExp <- getParameter(values, "filePath")
+            .map(getExpression)
+            .sequence
+          serviceDef <- getIntegratedService(serviceNameExp, executionResult)
+          _ <- serviceDef.toResult(
+            "Invalid or missing 'serviceName', 'service' or 'storage' property for ExternalStorage declaration"
+          )
+          fileType <- fileTypeExp.toResult(
+            "Invalid or missing 'fileType' property for ExternalStorage declaration"
+          )
+          filePath <- filePathExp.toResult(
+            "Invalid or missing 'filePath' property for ExternalStorage declaration"
+          )
+        } yield {
+          Some(
+            ExternalStorage(
+              serviceName = serviceNameExp,
+              fileType = fileType,
+              filePath = filePath
+            )
+          )
+        }
+      case _ =>
+        Failure(
+          "ExternalStorage declaration needs to get 'serviceName', 'fileType' and 'filePath' as constructor parameters"
+        )
+    }
+  }
+
+  override def cast(
+    value: String,
+    executionResult: TemplateExecutionResult
+  ): Result[ExternalStorage] =
+    decode[ExternalStorage](value).leftMap(FailureException(_))
+
+  override def internalFormat(value: OpenlawValue): Result[String] =
+    value match {
+      case extStorage: ExternalStorage =>
+        Success(extStorage.asJson.noSpaces)
+    }
+
+  override def thisType: VariableType = RegexType
+
+  private def getIntegratedService(
+    serviceNameExp: Expression,
+    executionResult: TemplateExecutionResult
+  ): Result[Option[IntegratedServiceDefinition]] =
+    serviceNameExp.evaluateT[OpenlawString](executionResult).map { option =>
+      option
+        .map(ServiceName(_))
+        .flatMap(executionResult.externalCallStructures.get)
+    }
+}

--- a/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/VariableType.scala
+++ b/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/VariableType.scala
@@ -3,8 +3,14 @@ package org.adridadou.openlaw.parser.template.variableTypes
 import java.time.{Clock, LocalDateTime, ZoneId, ZoneOffset}
 
 import org.adridadou.openlaw.parser.template._
-import org.adridadou.openlaw.parser.template.expressions.{Expression, ValueExpression}
-import org.adridadou.openlaw.parser.template.formatters.{DefaultFormatter, Formatter}
+import org.adridadou.openlaw.parser.template.expressions.{
+  Expression,
+  ValueExpression
+}
+import org.adridadou.openlaw.parser.template.formatters.{
+  DefaultFormatter,
+  Formatter
+}
 import cats.Eq
 import cats.implicits._
 import io.circe._
@@ -17,7 +23,10 @@ import cats.data.EitherT
 import org.adridadou.openlaw.result.{Failure, Result, Success}
 import LocalDateTimeHelper._
 import org.adridadou.openlaw._
-import org.adridadou.openlaw.oracles.{EthereumEventFilterExecution, PreparedERC712SmartContractCallExecution}
+import org.adridadou.openlaw.oracles.{
+  EthereumEventFilterExecution,
+  PreparedERC712SmartContractCallExecution
+}
 import org.adridadou.openlaw.vm.Executions
 
 trait NoShowInForm
@@ -25,27 +34,42 @@ trait NoShowInForm
 trait NoShowInFormButRender extends NoShowInForm
 
 trait ActionValue {
-  def nextActionSchedule(executionResult: TemplateExecutionResult, pastExecutions:List[OpenlawExecution]): Result[Option[LocalDateTime]]
-  def identifier(executionResult:TemplateExecutionResult):Result[ActionIdentifier]
-  def executions(executionResult: TemplateExecutionResult):Result[Option[Executions]] =
+  def nextActionSchedule(
+    executionResult: TemplateExecutionResult,
+    pastExecutions: List[OpenlawExecution]
+  ): Result[Option[LocalDateTime]]
+  def identifier(
+    executionResult: TemplateExecutionResult
+  ): Result[ActionIdentifier]
+  def executions(
+    executionResult: TemplateExecutionResult
+  ): Result[Option[Executions]] =
     identifier(executionResult).map(executionResult.executions.get(_))
 }
 
 trait ActionType extends NoShowInForm {
-  def actionValue(value:OpenlawValue): Result[ActionValue]
+  def actionValue(value: OpenlawValue): Result[ActionValue]
 }
 
 object OpenlawExecution {
-  implicit val openlawExecutionEnc:Encoder[OpenlawExecution] = (a: OpenlawExecution) => Json.obj(
-    "type" -> Json.fromString(a.typeIdentifier),
-    "value" -> a.serialize
-  )
-  implicit val openlawExecutionDec:Decoder[OpenlawExecution] = (c: HCursor) => c.downField("type").as[String]
-    .flatMap(convertOpenlawExecution(_, c.downField("value")))
+  implicit val openlawExecutionEnc: Encoder[OpenlawExecution] =
+    (a: OpenlawExecution) =>
+      Json.obj(
+        "type" -> Json.fromString(a.typeIdentifier),
+        "value" -> a.serialize
+    )
+  implicit val openlawExecutionDec: Decoder[OpenlawExecution] = (c: HCursor) =>
+    c.downField("type")
+      .as[String]
+      .flatMap(convertOpenlawExecution(_, c.downField("value")))
 
-  protected def className[T]()(implicit cls:ClassTag[T]):String = cls.runtimeClass.getName
+  protected def className[T]()(implicit cls: ClassTag[T]): String =
+    cls.runtimeClass.getName
 
-  private def convertOpenlawExecution(typeDefinition: String, cursor: ACursor):Decoder.Result[OpenlawExecution] = typeDefinition match {
+  private def convertOpenlawExecution(
+    typeDefinition: String,
+    cursor: ACursor
+  ): Decoder.Result[OpenlawExecution] = typeDefinition match {
     case _ if typeDefinition === className[EthereumEventFilterExecution] =>
       cursor.as[EthereumEventFilterExecution]
     case _ if typeDefinition === className[EthereumSmartContractExecution] =>
@@ -60,96 +84,146 @@ object OpenlawExecution {
 }
 
 object OpenlawExecutionInit {
-  implicit val openlawExecutionInitEnc:Encoder[OpenlawExecutionInit] = (a: OpenlawExecutionInit) => Json.obj(
-    "type" -> Json.fromString(a.typeIdentifier),
-    "value" -> Json.fromString(a.serialize)
-  )
-  implicit val openlawExecutionDec:Decoder[OpenlawExecutionInit] = (c: HCursor) => c.downField("type").as[String]
-    .flatMap(convertOpenlawExecutionInit(_, c.downField("value")))
+  implicit val openlawExecutionInitEnc: Encoder[OpenlawExecutionInit] =
+    (a: OpenlawExecutionInit) =>
+      Json.obj(
+        "type" -> Json.fromString(a.typeIdentifier),
+        "value" -> Json.fromString(a.serialize)
+    )
+  implicit val openlawExecutionDec: Decoder[OpenlawExecutionInit] =
+    (c: HCursor) =>
+      c.downField("type")
+        .as[String]
+        .flatMap(convertOpenlawExecutionInit(_, c.downField("value")))
 
-  protected def className[T]()(implicit cls:ClassTag[T]):String = cls.runtimeClass.getName
+  protected def className[T]()(implicit cls: ClassTag[T]): String =
+    cls.runtimeClass.getName
 
-  private def convertOpenlawExecutionInit(typeDefinition: String, cursor: ACursor):Decoder.Result[OpenlawExecutionInit] = typeDefinition match {
-    case _ if typeDefinition === className[PreparedERC712SmartContractCallExecution] =>
+  private def convertOpenlawExecutionInit(
+    typeDefinition: String,
+    cursor: ACursor
+  ): Decoder.Result[OpenlawExecutionInit] = typeDefinition match {
+    case _
+        if typeDefinition === className[
+          PreparedERC712SmartContractCallExecution
+        ] =>
       cursor.as[PreparedERC712SmartContractCallExecution]
   }
 }
 
 trait OpenlawExecutionInit extends OpenlawNativeValue {
-  protected def className[T]()(implicit cls:ClassTag[T]):String = cls.runtimeClass.getName
+  protected def className[T]()(implicit cls: ClassTag[T]): String =
+    cls.runtimeClass.getName
 
   def typeIdentifier: String
   def serialize: String
 }
 
 trait OpenlawExecution extends OpenlawNativeValue {
-  def scheduledDate:LocalDateTime
-  def executionDate:LocalDateTime
-  def executionStatus:OpenlawExecutionStatus
-  def key:Any
+  def scheduledDate: LocalDateTime
+  def executionDate: LocalDateTime
+  def executionStatus: OpenlawExecutionStatus
+  def key: Any
   def typeIdentifier: String
   def serialize: Json
-  protected def className[T]()(implicit cls:ClassTag[T]):String = cls.runtimeClass.getName
+  protected def className[T]()(implicit cls: ClassTag[T]): String =
+    cls.runtimeClass.getName
 }
 
 object EthereumSmartContractExecution {
-  implicit val smartContractExecutionEnc: Encoder[EthereumSmartContractExecution] = deriveEncoder
-  implicit val smartContractExecutionDec: Decoder[EthereumSmartContractExecution] = deriveDecoder
+  implicit val smartContractExecutionEnc
+    : Encoder[EthereumSmartContractExecution] = deriveEncoder
+  implicit val smartContractExecutionDec
+    : Decoder[EthereumSmartContractExecution] = deriveDecoder
 }
 
-final case class EthereumSmartContractExecution(scheduledDate:LocalDateTime, executionDate:LocalDateTime, executionStatus: OpenlawExecutionStatus = PendingExecution, tx:EthereumHash) extends OpenlawExecution {
+final case class EthereumSmartContractExecution(
+  scheduledDate: LocalDateTime,
+  executionDate: LocalDateTime,
+  executionStatus: OpenlawExecutionStatus = PendingExecution,
+  tx: EthereumHash
+) extends OpenlawExecution {
   def message: String = executionStatus match {
-    case PendingExecution => "the transaction has been submitted, waiting for the transaction to be executed"
-    case SuccessfulExecution => "the transaction has been added to the chain and successfully executed"
+    case PendingExecution =>
+      "the transaction has been submitted, waiting for the transaction to be executed"
+    case SuccessfulExecution =>
+      "the transaction has been added to the chain and successfully executed"
     case FailedExecution => "the transaction execution has failed"
   }
 
-  def key:EthereumHash = tx
+  def key: EthereumHash = tx
 
-  override def typeIdentifier: String = className[EthereumSmartContractExecution]
+  override def typeIdentifier: String =
+    className[EthereumSmartContractExecution]
   override def serialize: Json = this.asJson
 }
 
 case object RequestIdentifier {
-  implicit val requestIdentifierEnc: Encoder[RequestIdentifier] = (a: RequestIdentifier) => Json.fromString(a.identifier)
-  implicit val requestIdentifierDec: Decoder[RequestIdentifier] = (c: HCursor) => c.as[String].map(RequestIdentifier(_))
+  implicit val requestIdentifierEnc: Encoder[RequestIdentifier] =
+    (a: RequestIdentifier) => Json.fromString(a.identifier)
+  implicit val requestIdentifierDec: Decoder[RequestIdentifier] =
+    (c: HCursor) => c.as[String].map(RequestIdentifier(_))
 
-  implicit val requestIdentifierEq:Eq[RequestIdentifier] = Eq.fromUniversalEquals
+  implicit val requestIdentifierEq: Eq[RequestIdentifier] =
+    Eq.fromUniversalEquals
 }
 
-final case class RequestIdentifier(identifier:String)
+final case class RequestIdentifier(identifier: String)
 
 object SuccessfulExternalCallExecution {
-  implicit val successfulExternalCallExecutionEnc:Encoder[SuccessfulExternalCallExecution] = deriveEncoder
-  implicit val successfulExternalCallExecutionDec:Decoder[SuccessfulExternalCallExecution] = deriveDecoder
+  implicit val successfulExternalCallExecutionEnc
+    : Encoder[SuccessfulExternalCallExecution] = deriveEncoder
+  implicit val successfulExternalCallExecutionDec
+    : Decoder[SuccessfulExternalCallExecution] = deriveDecoder
 }
 
-final case class SuccessfulExternalCallExecution(scheduledDate:LocalDateTime, executionDate:LocalDateTime, result: String, requestIdentifier: RequestIdentifier) extends ExternalCallExecution {
-  def message: String = "the request has been added to the integrator queue and successfully executed"
+final case class SuccessfulExternalCallExecution(
+  scheduledDate: LocalDateTime,
+  executionDate: LocalDateTime,
+  result: String,
+  requestIdentifier: RequestIdentifier
+) extends ExternalCallExecution {
+  def message: String =
+    "the request has been added to the integrator queue and successfully executed"
 
-  override def typeIdentifier: String = className[SuccessfulExternalCallExecution]
+  override def typeIdentifier: String =
+    className[SuccessfulExternalCallExecution]
   override def serialize: Json = this.asJson
   override def executionStatus: OpenlawExecutionStatus = SuccessfulExecution
 }
 
 object PendingExternalCallExecution {
-  implicit val pendingExternalCallExecutionEnc:Encoder[PendingExternalCallExecution] = deriveEncoder
-  implicit val pendingExternalCallExecutionDec:Decoder[PendingExternalCallExecution] = deriveDecoder
+  implicit val pendingExternalCallExecutionEnc
+    : Encoder[PendingExternalCallExecution] = deriveEncoder
+  implicit val pendingExternalCallExecutionDec
+    : Decoder[PendingExternalCallExecution] = deriveDecoder
 }
 
-final case class PendingExternalCallExecution(scheduledDate:LocalDateTime, executionDate:LocalDateTime, requestIdentifier: RequestIdentifier) extends ExternalCallExecution {
-  def message: String = "the request has been submitted, waiting for the request to be executed"
+final case class PendingExternalCallExecution(
+  scheduledDate: LocalDateTime,
+  executionDate: LocalDateTime,
+  requestIdentifier: RequestIdentifier
+) extends ExternalCallExecution {
+  def message: String =
+    "the request has been submitted, waiting for the request to be executed"
   override def typeIdentifier: String = className[PendingExternalCallExecution]
   override def serialize: Json = this.asJson
   override def executionStatus: OpenlawExecutionStatus = PendingExecution
 }
 
 object FailedExternalCallExecution {
-  implicit val failedExternalCallExecutionEnc:Encoder[FailedExternalCallExecution] = deriveEncoder
-  implicit val failedExternalCallExecutionDec:Decoder[FailedExternalCallExecution] = deriveDecoder
+  implicit val failedExternalCallExecutionEnc
+    : Encoder[FailedExternalCallExecution] = deriveEncoder
+  implicit val failedExternalCallExecutionDec
+    : Decoder[FailedExternalCallExecution] = deriveDecoder
 }
 
-final case class FailedExternalCallExecution(scheduledDate:LocalDateTime, executionDate:LocalDateTime, errorMessage: String, requestIdentifier: RequestIdentifier) extends ExternalCallExecution {
+final case class FailedExternalCallExecution(
+  scheduledDate: LocalDateTime,
+  executionDate: LocalDateTime,
+  errorMessage: String,
+  requestIdentifier: RequestIdentifier
+) extends ExternalCallExecution {
   def message: String = s"the request execution has failed. $errorMessage"
   override def typeIdentifier: String = className[FailedExternalCallExecution]
   override def serialize: Json = this.asJson
@@ -157,12 +231,12 @@ final case class FailedExternalCallExecution(scheduledDate:LocalDateTime, execut
 }
 
 sealed trait ExternalCallExecution extends OpenlawExecution {
-  val requestIdentifier:RequestIdentifier
+  val requestIdentifier: RequestIdentifier
 
-  def key:String = requestIdentifier.identifier
+  def key: String = requestIdentifier.identifier
 }
 
-sealed abstract class OpenlawExecutionStatus(val name:String)
+sealed abstract class OpenlawExecutionStatus(val name: String)
 
 case object PendingExecution extends OpenlawExecutionStatus("pending")
 case object SuccessfulExecution extends OpenlawExecutionStatus("success")
@@ -170,43 +244,62 @@ case object FailedExecution extends OpenlawExecutionStatus("failed")
 
 object OpenlawExecutionStatus {
 
-  def apply(name:String):OpenlawExecutionStatus = name match {
+  def apply(name: String): OpenlawExecutionStatus = name match {
     case "success" => SuccessfulExecution
-    case "failed" => FailedExecution
-    case _ => PendingExecution
+    case "failed"  => FailedExecution
+    case _         => PendingExecution
   }
 
-  implicit val executionStatusDecoder: Decoder[OpenlawExecutionStatus] = (c: HCursor) => for {
-      name <- c.as[String]
-    } yield OpenlawExecutionStatus(name)
+  implicit val executionStatusDecoder: Decoder[OpenlawExecutionStatus] =
+    (c: HCursor) =>
+      for {
+        name <- c.as[String]
+      } yield OpenlawExecutionStatus(name)
 
-  implicit val executionStatusEncoder: Encoder[OpenlawExecutionStatus] = (a: OpenlawExecutionStatus) => Json.fromString(a.name)
+  implicit val executionStatusEncoder: Encoder[OpenlawExecutionStatus] =
+    (a: OpenlawExecutionStatus) => Json.fromString(a.name)
 
-  implicit val eqForExecutionStatus: Eq[OpenlawExecutionStatus] = Eq.fromUniversalEquals
+  implicit val eqForExecutionStatus: Eq[OpenlawExecutionStatus] =
+    Eq.fromUniversalEquals
 }
 
 trait ParameterType {
-  val typeParameter:VariableType
+  val typeParameter: VariableType
 }
 
 trait ParameterTypeProvider {
-  def createParameterInstance(parameterType:VariableType):VariableType with ParameterType
+  def createParameterInstance(
+    parameterType: VariableType
+  ): VariableType with ParameterType
 }
 
 abstract class VariableType(val name: String) {
 
   def serialize: Json = Json.obj("name" -> io.circe.Json.fromString(name))
 
-  def validateOperation(expr: ValueExpression, executionResult: TemplateExecutionResult): Result[Unit] = Success(())
+  def validateOperation(
+    expr: ValueExpression,
+    executionResult: TemplateExecutionResult
+  ): Result[Unit] = Success(())
 
-  def accessVariables(name:VariableName, keys:List[VariableMemberKey], executionResult: TemplateExecutionResult): Result[List[VariableName]] =
+  def accessVariables(
+    name: VariableName,
+    keys: List[VariableMemberKey],
+    executionResult: TemplateExecutionResult
+  ): Result[List[VariableName]] =
     Success(List(name))
 
-  def operationWith(rightType: VariableType, operation: ValueOperation): VariableType =
+  def operationWith(rightType: VariableType,
+                    operation: ValueOperation): VariableType =
     this
 
-  def access(value: OpenlawValue, variableName:VariableName, keys: List[VariableMemberKey], executionResult:TemplateExecutionResult): Result[Option[OpenlawValue]] = {
-    if(keys.isEmpty) {
+  def access(
+    value: OpenlawValue,
+    variableName: VariableName,
+    keys: List[VariableMemberKey],
+    executionResult: TemplateExecutionResult
+  ): Result[Option[OpenlawValue]] = {
+    if (keys.isEmpty) {
       Success(Some(value))
     } else {
       Failure(s"The variable $variableName of type $name has no properties")
@@ -218,85 +311,144 @@ abstract class VariableType(val name: String) {
   def checkTypeName(nameToCheck: String): Boolean =
     this.name.equalsIgnoreCase(nameToCheck)
 
-  def validateKeys(variableName:VariableName, keys:List[VariableMemberKey], expression:Expression, executionResult: TemplateExecutionResult): Result[Unit] =
-    keys.headOption.map(_ => Failure(s"The variable $variableName of type $name has no properties")).getOrElse(Success(()))
+  def validateKeys(variableName: VariableName,
+                   keys: List[VariableMemberKey],
+                   expression: Expression,
+                   executionResult: TemplateExecutionResult): Result[Unit] =
+    keys.headOption
+      .map(
+        _ =>
+          Failure(s"The variable $variableName of type $name has no properties")
+      )
+      .getOrElse(Success(()))
 
-  def keysType(keys: List[VariableMemberKey], expression: Expression, executionResult: TemplateExecutionResult):Result[VariableType] = if(keys.nonEmpty) {
-    Failure(s"the type $name has no properties (tried to access ${keys.mkString(".")})")
-  } else {
-    Success(thisType)
-  }
+  def keysType(keys: List[VariableMemberKey],
+               expression: Expression,
+               executionResult: TemplateExecutionResult): Result[VariableType] =
+    if (keys.nonEmpty) {
+      Failure(
+        s"the type $name has no properties (tried to access ${keys.mkString(".")})"
+      )
+    } else {
+      Success(thisType)
+    }
 
-  def combineConverted[U <: OpenlawValue, Y <: OpenlawValue]
-    (optLeft: Option[OpenlawValue], optRight: Option[OpenlawValue])
-    (operation: PartialFunction[(U#T, U#T), Result[Y]])
-    (implicit ct: ClassTag[U])
-  : Result[Option[Y]] =
+  def combineConverted[U <: OpenlawValue, Y <: OpenlawValue](
+    optLeft: Option[OpenlawValue],
+    optRight: Option[OpenlawValue]
+  )(
+    operation: PartialFunction[(U#T, U#T), Result[Y]]
+  )(implicit ct: ClassTag[U]): Result[Option[Y]] =
     combineConverted[U, U, Y](optLeft, optRight)(operation)
 
-  def combineConverted[U <: OpenlawValue, V <: OpenlawValue, Y <: OpenlawValue]
-    (optLeft: Option[OpenlawValue], optRight: Option[OpenlawValue])
-    (operation: PartialFunction[(U#T, V#T), Result[Y]])
-    (implicit ct1: ClassTag[U], ct2: ClassTag[V])
-  : Result[Option[Y]] = {
+  def combineConverted[U <: OpenlawValue, V <: OpenlawValue, Y <: OpenlawValue](
+    optLeft: Option[OpenlawValue],
+    optRight: Option[OpenlawValue]
+  )(
+    operation: PartialFunction[(U#T, V#T), Result[Y]]
+  )(implicit ct1: ClassTag[U], ct2: ClassTag[V]): Result[Option[Y]] = {
     (for {
       left <- EitherT(optLeft.map(VariableType.convert[U]))
       right <- EitherT(optRight.map(VariableType.convert[V]))
     } yield {
       if (operation.isDefinedAt(left -> right)) operation(left -> right)
-      else Failure(s"no matching case in partial function for arguments $left and $right")
-    })
-      .value
+      else
+        Failure(
+          s"no matching case in partial function for arguments $left and $right"
+        )
+    }).value
       .map(_.flatten)
       .sequence
   }
 
-  def combine[Y <: OpenlawValue](optLeft: Option[OpenlawValue], optRight: Option[OpenlawValue])(operation: PartialFunction[(OpenlawValue, OpenlawValue), Result[Y]]): Result[Option[Y]] = {
+  def combine[Y <: OpenlawValue](optLeft: Option[OpenlawValue],
+                                 optRight: Option[OpenlawValue])(
+    operation: PartialFunction[(OpenlawValue, OpenlawValue), Result[Y]]
+  ): Result[Option[Y]] = {
     (for {
       left <- optLeft
       right <- optRight
     } yield {
       if (operation.isDefinedAt(left -> right)) operation(left -> right)
-      else Failure(s"no matching case in partial function for arguments $left and $right")
-    })
-      .sequence
+      else
+        Failure(
+          s"no matching case in partial function for arguments $left and $right"
+        )
+    }).sequence
   }
 
-  def plus(optLeft: Option[OpenlawValue], optRight: Option[OpenlawValue], executionResult: TemplateExecutionResult): Result[Option[OpenlawValue]] =
-    Failure(new UnsupportedOperationException(s"$name type does not support addition"))
-  def minus(optLeft: Option[OpenlawValue], optRight: Option[OpenlawValue], executionResult: TemplateExecutionResult): Result[Option[OpenlawValue]] =
-    Failure(new UnsupportedOperationException(s"$name type does not support substraction"))
-  def multiply(optLeft: Option[OpenlawValue], optRight: Option[OpenlawValue], executionResult: TemplateExecutionResult): Result[Option[OpenlawValue]] =
-    Failure(new UnsupportedOperationException(s"$name type does not support multiplication"))
-  def divide(optLeft: Option[OpenlawValue], optRight: Option[OpenlawValue], executionResult: TemplateExecutionResult): Result[Option[OpenlawValue]] =
-    Failure(new UnsupportedOperationException(s"$name type does not support division"))
+  def plus(
+    optLeft: Option[OpenlawValue],
+    optRight: Option[OpenlawValue],
+    executionResult: TemplateExecutionResult
+  ): Result[Option[OpenlawValue]] =
+    Failure(
+      new UnsupportedOperationException(s"$name type does not support addition")
+    )
+  def minus(
+    optLeft: Option[OpenlawValue],
+    optRight: Option[OpenlawValue],
+    executionResult: TemplateExecutionResult
+  ): Result[Option[OpenlawValue]] =
+    Failure(
+      new UnsupportedOperationException(
+        s"$name type does not support substraction"
+      )
+    )
+  def multiply(
+    optLeft: Option[OpenlawValue],
+    optRight: Option[OpenlawValue],
+    executionResult: TemplateExecutionResult
+  ): Result[Option[OpenlawValue]] =
+    Failure(
+      new UnsupportedOperationException(
+        s"$name type does not support multiplication"
+      )
+    )
+  def divide(
+    optLeft: Option[OpenlawValue],
+    optRight: Option[OpenlawValue],
+    executionResult: TemplateExecutionResult
+  ): Result[Option[OpenlawValue]] =
+    Failure(
+      new UnsupportedOperationException(s"$name type does not support division")
+    )
 
-  def isCompatibleType(otherType: VariableType, operation: ValueOperation): Boolean =
+  def isCompatibleType(otherType: VariableType,
+                       operation: ValueOperation): Boolean =
     otherType === this
 
-  def cast(value: String, executionResult:TemplateExecutionResult):Result[OpenlawValue]
+  def cast(value: String,
+           executionResult: TemplateExecutionResult): Result[OpenlawValue]
 
-  def missingValueFormat(name: String): List[AgreementElement] = List(FreeText(Text(s"[[${name}]]")))
+  def missingValueFormat(name: String): List[AgreementElement] =
+    List(FreeText(Text(s"[[${name}]]")))
 
   def internalFormat(value: OpenlawValue): Result[String]
 
-  def construct(constructorParams: Parameter, executionResult: TemplateExecutionResult): Result[Option[OpenlawValue]] = constructorParams match {
-      case OneValueParameter(expr) =>
-        expr.evaluate(executionResult)
-      case Parameters(parameterMap) =>
-        parameterMap.toMap.get("value") match {
-          case Some(parameter) =>
-            construct(parameter, executionResult)
-          case None => Success(None)
-        }
-      case _ =>
-        Failure(s"the constructor for $name only handles single values")
-    }
+  def construct(
+    constructorParams: Parameter,
+    executionResult: TemplateExecutionResult
+  ): Result[Option[OpenlawValue]] = constructorParams match {
+    case OneValueParameter(expr) =>
+      expr.evaluate(executionResult)
+    case Parameters(parameterMap) =>
+      parameterMap.toMap.get("value") match {
+        case Some(parameter) =>
+          construct(parameter, executionResult)
+        case None => Success(None)
+      }
+    case _ =>
+      Failure(s"the constructor for $name only handles single values")
+  }
 
   def defaultFormatter: Formatter =
     new DefaultFormatter
 
-  def getFormatter(name:FormatterDefinition, executionResult:TemplateExecutionResult): Result[Formatter] = Success(defaultFormatter)
+  def getFormatter(
+    name: FormatterDefinition,
+    executionResult: TemplateExecutionResult
+  ): Result[Formatter] = Success(defaultFormatter)
 
   def getSingleParameter(constructorParams: Parameter): Result[Expression] =
     constructorParams match {
@@ -307,75 +459,91 @@ abstract class VariableType(val name: String) {
 
   def handleTry[T](thisTry: Try[T]): T =
     thisTry match {
-      case scala.util.Success(v) => v
+      case scala.util.Success(v)  => v
       case scala.util.Failure(ex) => throw ex
     }
 
-  def thisType:VariableType
+  def thisType: VariableType
 
-  def getExpression(params:Map[String,Parameter], names:String*): Result[Expression] =
-    getParameter(params, names:_*)
+  def getExpression(params: Map[String, Parameter],
+                    names: String*): Result[Expression] =
+    getParameter(params, names: _*)
       .map(getExpression)
       .sequence
       .flatMap {
         case Some(expr) => Success(expr)
-        case None => Failure(s"parameter $name not found. available parameters: ${params.keys.mkString(",")}")
+        case None =>
+          Failure(
+            s"parameter $name not found. available parameters: ${params.keys.mkString(",")}"
+          )
       }
 
-  def getParameter(params:Map[String,Parameter], names:String*):Option[Parameter] =
+  def getParameter(params: Map[String, Parameter],
+                   names: String*): Option[Parameter] =
     names.flatMap(params.get).headOption
 
-  def getExpression(param:Parameter): Result[Expression] = param match {
+  def getExpression(param: Parameter): Result[Expression] = param match {
     case OneValueParameter(expr) => Success(expr)
-    case _ => Failure("invalid parameter type " + param.getClass.getSimpleName + " expecting single expression")
+    case _ =>
+      Failure(
+        "invalid parameter type " + param.getClass.getSimpleName + " expecting single expression"
+      )
   }
 
-  def format(formatter:Option[FormatterDefinition], value:OpenlawValue, executionResult: TemplateExecutionResult): Result[List[AgreementElement]] =
+  def format(
+    formatter: Option[FormatterDefinition],
+    value: OpenlawValue,
+    executionResult: TemplateExecutionResult
+  ): Result[List[AgreementElement]] =
     formatter
       .map(getFormatter(_, executionResult))
       .getOrElse(Success(defaultFormatter))
       .flatMap(_.format(value, executionResult))
 
-  def getMandatoryParameter(name:String, parameter:Parameters): Result[Parameter] = {
+  def getMandatoryParameter(name: String,
+                            parameter: Parameters): Result[Parameter] = {
     parameter.parameterMap.toMap.get(name) match {
       case Some(param) => Success(param)
-      case None => Failure(s"mandatory parameter $name could not be found")
+      case None        => Failure(s"mandatory parameter $name could not be found")
     }
   }
 }
 
 object VariableType {
 
-  def allTypes():List[VariableType] = List(
-    AbstractCollectionType,
-    AbstractFunctionType,
-    OLOwnType,
-    AddressType,
-    ChoiceType,
-    ClauseType,
-    DateType,
-    DateTimeType,
-    AbstractDomainType,
-    EthAddressType,
-    EthTxHashType,
-    EthereumCallType,
-    EthereumEventFilterType,
-    ExternalCallType,
-    ExternalSignatureType,
-    IdentityType,
-    LargeTextType,
-    LinkType,
-    ImageType,
-    NumberType,
-    PeriodType,
-    SectionType,
-    SmartContractMetadataType,
-    AbstractStructureType,
-    TemplateType,
-    TextType,
-    ValidationType,
-    RegexType,
-    YesNoType)
+  def allTypes(): List[VariableType] =
+    List(
+      AbstractCollectionType,
+      AbstractFunctionType,
+      OLOwnType,
+      AddressType,
+      ChoiceType,
+      ClauseType,
+      DateType,
+      DateTimeType,
+      AbstractDomainType,
+      EthAddressType,
+      EthTxHashType,
+      EthereumCallType,
+      EthereumEventFilterType,
+      ExternalCallType,
+      ExternalSignatureType,
+      ExternalStorageType,
+      IdentityType,
+      LargeTextType,
+      LinkType,
+      ImageType,
+      NumberType,
+      PeriodType,
+      SectionType,
+      SmartContractMetadataType,
+      AbstractStructureType,
+      TemplateType,
+      TextType,
+      ValidationType,
+      RegexType,
+      YesNoType
+    )
 
   def getByName(name: String): Option[VariableType] =
     allTypes().find(_.name === name)
@@ -383,28 +551,50 @@ object VariableType {
   implicit val eqForVariableType: Eq[VariableType] =
     (x: VariableType, y: VariableType) => x == y
 
-  def getPeriod(v: Expression, executionResult: TemplateExecutionResult): Result[Period] =
-    get(v,executionResult, PeriodType.cast)
-  def getEthereumAddress(v: Expression, executionResult: TemplateExecutionResult): Result[EthereumAddress] =
-    get(v,executionResult,EthAddressType.cast)
-  def getDate(v: Expression, executionResult: TemplateExecutionResult): Result[OpenlawDateTime] =
-    get(v,executionResult, DateTimeType.cast)
-  def getMetadata(v: Expression, executionResult: TemplateExecutionResult): Result[SmartContractMetadata] =
-    get(v,executionResult,SmartContractMetadataType.cast)
-  def getString(v: Expression, executionResult: TemplateExecutionResult): Result[String] =
-    get[OpenlawString](v,executionResult, (str,_) => Success(str)).map(_.underlying)
+  def getPeriod(v: Expression,
+                executionResult: TemplateExecutionResult): Result[Period] =
+    get(v, executionResult, PeriodType.cast)
+  def getEthereumAddress(
+    v: Expression,
+    executionResult: TemplateExecutionResult
+  ): Result[EthereumAddress] =
+    get(v, executionResult, EthAddressType.cast)
+  def getDate(
+    v: Expression,
+    executionResult: TemplateExecutionResult
+  ): Result[OpenlawDateTime] =
+    get(v, executionResult, DateTimeType.cast)
+  def getMetadata(
+    v: Expression,
+    executionResult: TemplateExecutionResult
+  ): Result[SmartContractMetadata] =
+    get(v, executionResult, SmartContractMetadataType.cast)
+  def getString(v: Expression,
+                executionResult: TemplateExecutionResult): Result[String] =
+    get[OpenlawString](v, executionResult, (str, _) => Success(str))
+      .map(_.underlying)
 
-  def get[T <: OpenlawValue](expr: Expression, executionResult: TemplateExecutionResult, cast: (String,TemplateExecutionResult) => Result[T])(implicit classTag: ClassTag[T]): Result[T] =
+  def get[T <: OpenlawValue](
+    expr: Expression,
+    executionResult: TemplateExecutionResult,
+    cast: (String, TemplateExecutionResult) => Result[T]
+  )(implicit classTag: ClassTag[T]): Result[T] =
     expr
       .evaluate(executionResult)
       .flatMap {
-        case Some(value:T) => Success(value)
-        case Some(value:OpenlawString) => cast(value.underlying, executionResult)
-        case Some(value) => Failure("cannot get value of type " + value.getClass.getSimpleName + ". expecting " + classTag.runtimeClass.getSimpleName)
+        case Some(value: T) => Success(value)
+        case Some(value: OpenlawString) =>
+          cast(value.underlying, executionResult)
+        case Some(value) =>
+          Failure(
+            "cannot get value of type " + value.getClass.getSimpleName + ". expecting " + classTag.runtimeClass.getSimpleName
+          )
         case None => Failure("could not get the value. Missing data")
       }
 
-  def convert[U <: OpenlawValue](value:OpenlawValue)(implicit classTag: ClassTag[U]): Result[U#T] = value match {
+  def convert[U <: OpenlawValue](
+    value: OpenlawValue
+  )(implicit classTag: ClassTag[U]): Result[U#T] = value match {
     case convertedValue: U =>
       Success(convertedValue.underlying)
     case other =>
@@ -419,26 +609,46 @@ object VariableType {
   implicit val variableTypeEnc: Encoder[VariableType] = (a: VariableType) =>
     a.serialize
 
-  implicit val variableTypeDec: Decoder[VariableType] = (c: HCursor) => c.downField("name").as[String]
-    .flatMap(name => VariableType.allTypes().find(_.name === name) match {
-        case Some(varType) => Right(varType)
-        case None => createCustomType(c, name)
-      })
+  implicit val variableTypeDec: Decoder[VariableType] = (c: HCursor) =>
+    c.downField("name")
+      .as[String]
+      .flatMap(
+        name =>
+          VariableType.allTypes().find(_.name === name) match {
+            case Some(varType) => Right(varType)
+            case None          => createCustomType(c, name)
+        }
+    )
 
-  private def createCustomType(cursor: HCursor, name:String):Decoder.Result[VariableType] = {
+  private def createCustomType(cursor: HCursor,
+                               name: String): Decoder.Result[VariableType] = {
     DefinedStructureType.definedStructureTypeDec(cursor) match {
       case Right(value) => Right(value)
-      case Left(_) => DefinedChoiceType.definedChoiceTypeDec(cursor) match {
-        case Right(value) => Right(value)
-        case Left(_) => Left(DecodingFailure(s"unknown type $name. or error while decoding", Nil))
-      }
+      case Left(_) =>
+        DefinedChoiceType.definedChoiceTypeDec(cursor) match {
+          case Right(value) => Right(value)
+          case Left(_) =>
+            Left(
+              DecodingFailure(
+                s"unknown type $name. or error while decoding",
+                Nil
+              )
+            )
+        }
     }
     DefinedDomainType.definedDomainTypeDec(cursor) match {
       case Right(value) => Right(value)
-      case Left(_) => DefinedChoiceType.definedChoiceTypeDec(cursor) match {
-        case Right(value) => Right(value)
-        case Left(_) => Left(DecodingFailure(s"unknown type $name. or error while decoding", Nil))
-      }
+      case Left(_) =>
+        DefinedChoiceType.definedChoiceTypeDec(cursor) match {
+          case Right(value) => Right(value)
+          case Left(_) =>
+            Left(
+              DecodingFailure(
+                s"unknown type $name. or error while decoding",
+                Nil
+              )
+            )
+        }
     }
   }
 }
@@ -447,19 +657,23 @@ object LocalDateTimeHelper {
   implicit val dateDecoder: Decoder[LocalDateTime] = (c: HCursor) => {
     for {
       epoch <- c.as[Long]
-    } yield LocalDateTime.ofEpochSecond(epoch, 0,ZoneOffset.UTC)
+    } yield LocalDateTime.ofEpochSecond(epoch, 0, ZoneOffset.UTC)
   }
-  implicit val dateEncoder: Encoder[Clock] = (a: Clock) => Json.fromString(a.getZone.getId)
+  implicit val dateEncoder: Encoder[Clock] = (a: Clock) =>
+    Json.fromString(a.getZone.getId)
 
   implicit val clockDecoder: Decoder[Clock] = (c: HCursor) => {
     for {
       zoneId <- c.as[String]
     } yield Clock.system(ZoneId.of(zoneId))
   }
-  implicit val clockEncoder: Encoder[LocalDateTime] = (a: LocalDateTime) => Json.fromLong(a.toEpochSecond(ZoneOffset.UTC))
+  implicit val clockEncoder: Encoder[LocalDateTime] = (a: LocalDateTime) =>
+    Json.fromLong(a.toEpochSecond(ZoneOffset.UTC))
   implicit val eqForLocalDateTime: Eq[LocalDateTime] = Eq.fromUniversalEquals
 
-  implicit val dateKeyEncoder:KeyEncoder[LocalDateTime] = (key: LocalDateTime) => key.toEpochSecond(ZoneOffset.UTC).toString
+  implicit val dateKeyEncoder: KeyEncoder[LocalDateTime] =
+    (key: LocalDateTime) => key.toEpochSecond(ZoneOffset.UTC).toString
 
-  implicit val dateKeyDecoder:KeyDecoder[LocalDateTime] = (key: String) => Try(LocalDateTime.ofEpochSecond(key.toLong, 0, ZoneOffset.UTC)).toOption
+  implicit val dateKeyDecoder: KeyDecoder[LocalDateTime] = (key: String) =>
+    Try(LocalDateTime.ofEpochSecond(key.toLong, 0, ZoneOffset.UTC)).toOption
 }

--- a/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/VariableType.scala
+++ b/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/VariableType.scala
@@ -3,14 +3,8 @@ package org.adridadou.openlaw.parser.template.variableTypes
 import java.time.{Clock, LocalDateTime, ZoneId, ZoneOffset}
 
 import org.adridadou.openlaw.parser.template._
-import org.adridadou.openlaw.parser.template.expressions.{
-  Expression,
-  ValueExpression
-}
-import org.adridadou.openlaw.parser.template.formatters.{
-  DefaultFormatter,
-  Formatter
-}
+import org.adridadou.openlaw.parser.template.expressions.{Expression, ValueExpression}
+import org.adridadou.openlaw.parser.template.formatters.{DefaultFormatter, Formatter}
 import cats.Eq
 import cats.implicits._
 import io.circe._
@@ -23,10 +17,7 @@ import cats.data.EitherT
 import org.adridadou.openlaw.result.{Failure, Result, Success}
 import LocalDateTimeHelper._
 import org.adridadou.openlaw._
-import org.adridadou.openlaw.oracles.{
-  EthereumEventFilterExecution,
-  PreparedERC712SmartContractCallExecution
-}
+import org.adridadou.openlaw.oracles.{EthereumEventFilterExecution, PreparedERC712SmartContractCallExecution}
 import org.adridadou.openlaw.vm.Executions
 
 trait NoShowInForm
@@ -34,42 +25,27 @@ trait NoShowInForm
 trait NoShowInFormButRender extends NoShowInForm
 
 trait ActionValue {
-  def nextActionSchedule(
-    executionResult: TemplateExecutionResult,
-    pastExecutions: List[OpenlawExecution]
-  ): Result[Option[LocalDateTime]]
-  def identifier(
-    executionResult: TemplateExecutionResult
-  ): Result[ActionIdentifier]
-  def executions(
-    executionResult: TemplateExecutionResult
-  ): Result[Option[Executions]] =
+  def nextActionSchedule(executionResult: TemplateExecutionResult, pastExecutions:List[OpenlawExecution]): Result[Option[LocalDateTime]]
+  def identifier(executionResult:TemplateExecutionResult):Result[ActionIdentifier]
+  def executions(executionResult: TemplateExecutionResult):Result[Option[Executions]] =
     identifier(executionResult).map(executionResult.executions.get(_))
 }
 
 trait ActionType extends NoShowInForm {
-  def actionValue(value: OpenlawValue): Result[ActionValue]
+  def actionValue(value:OpenlawValue): Result[ActionValue]
 }
 
 object OpenlawExecution {
-  implicit val openlawExecutionEnc: Encoder[OpenlawExecution] =
-    (a: OpenlawExecution) =>
-      Json.obj(
-        "type" -> Json.fromString(a.typeIdentifier),
-        "value" -> a.serialize
-    )
-  implicit val openlawExecutionDec: Decoder[OpenlawExecution] = (c: HCursor) =>
-    c.downField("type")
-      .as[String]
-      .flatMap(convertOpenlawExecution(_, c.downField("value")))
+  implicit val openlawExecutionEnc:Encoder[OpenlawExecution] = (a: OpenlawExecution) => Json.obj(
+    "type" -> Json.fromString(a.typeIdentifier),
+    "value" -> a.serialize
+  )
+  implicit val openlawExecutionDec:Decoder[OpenlawExecution] = (c: HCursor) => c.downField("type").as[String]
+    .flatMap(convertOpenlawExecution(_, c.downField("value")))
 
-  protected def className[T]()(implicit cls: ClassTag[T]): String =
-    cls.runtimeClass.getName
+  protected def className[T]()(implicit cls:ClassTag[T]):String = cls.runtimeClass.getName
 
-  private def convertOpenlawExecution(
-    typeDefinition: String,
-    cursor: ACursor
-  ): Decoder.Result[OpenlawExecution] = typeDefinition match {
+  private def convertOpenlawExecution(typeDefinition: String, cursor: ACursor):Decoder.Result[OpenlawExecution] = typeDefinition match {
     case _ if typeDefinition === className[EthereumEventFilterExecution] =>
       cursor.as[EthereumEventFilterExecution]
     case _ if typeDefinition === className[EthereumSmartContractExecution] =>
@@ -84,146 +60,96 @@ object OpenlawExecution {
 }
 
 object OpenlawExecutionInit {
-  implicit val openlawExecutionInitEnc: Encoder[OpenlawExecutionInit] =
-    (a: OpenlawExecutionInit) =>
-      Json.obj(
-        "type" -> Json.fromString(a.typeIdentifier),
-        "value" -> Json.fromString(a.serialize)
-    )
-  implicit val openlawExecutionDec: Decoder[OpenlawExecutionInit] =
-    (c: HCursor) =>
-      c.downField("type")
-        .as[String]
-        .flatMap(convertOpenlawExecutionInit(_, c.downField("value")))
+  implicit val openlawExecutionInitEnc:Encoder[OpenlawExecutionInit] = (a: OpenlawExecutionInit) => Json.obj(
+    "type" -> Json.fromString(a.typeIdentifier),
+    "value" -> Json.fromString(a.serialize)
+  )
+  implicit val openlawExecutionDec:Decoder[OpenlawExecutionInit] = (c: HCursor) => c.downField("type").as[String]
+    .flatMap(convertOpenlawExecutionInit(_, c.downField("value")))
 
-  protected def className[T]()(implicit cls: ClassTag[T]): String =
-    cls.runtimeClass.getName
+  protected def className[T]()(implicit cls:ClassTag[T]):String = cls.runtimeClass.getName
 
-  private def convertOpenlawExecutionInit(
-    typeDefinition: String,
-    cursor: ACursor
-  ): Decoder.Result[OpenlawExecutionInit] = typeDefinition match {
-    case _
-        if typeDefinition === className[
-          PreparedERC712SmartContractCallExecution
-        ] =>
+  private def convertOpenlawExecutionInit(typeDefinition: String, cursor: ACursor):Decoder.Result[OpenlawExecutionInit] = typeDefinition match {
+    case _ if typeDefinition === className[PreparedERC712SmartContractCallExecution] =>
       cursor.as[PreparedERC712SmartContractCallExecution]
   }
 }
 
 trait OpenlawExecutionInit extends OpenlawNativeValue {
-  protected def className[T]()(implicit cls: ClassTag[T]): String =
-    cls.runtimeClass.getName
+  protected def className[T]()(implicit cls:ClassTag[T]):String = cls.runtimeClass.getName
 
   def typeIdentifier: String
   def serialize: String
 }
 
 trait OpenlawExecution extends OpenlawNativeValue {
-  def scheduledDate: LocalDateTime
-  def executionDate: LocalDateTime
-  def executionStatus: OpenlawExecutionStatus
-  def key: Any
+  def scheduledDate:LocalDateTime
+  def executionDate:LocalDateTime
+  def executionStatus:OpenlawExecutionStatus
+  def key:Any
   def typeIdentifier: String
   def serialize: Json
-  protected def className[T]()(implicit cls: ClassTag[T]): String =
-    cls.runtimeClass.getName
+  protected def className[T]()(implicit cls:ClassTag[T]):String = cls.runtimeClass.getName
 }
 
 object EthereumSmartContractExecution {
-  implicit val smartContractExecutionEnc
-    : Encoder[EthereumSmartContractExecution] = deriveEncoder
-  implicit val smartContractExecutionDec
-    : Decoder[EthereumSmartContractExecution] = deriveDecoder
+  implicit val smartContractExecutionEnc: Encoder[EthereumSmartContractExecution] = deriveEncoder
+  implicit val smartContractExecutionDec: Decoder[EthereumSmartContractExecution] = deriveDecoder
 }
 
-final case class EthereumSmartContractExecution(
-  scheduledDate: LocalDateTime,
-  executionDate: LocalDateTime,
-  executionStatus: OpenlawExecutionStatus = PendingExecution,
-  tx: EthereumHash
-) extends OpenlawExecution {
+final case class EthereumSmartContractExecution(scheduledDate:LocalDateTime, executionDate:LocalDateTime, executionStatus: OpenlawExecutionStatus = PendingExecution, tx:EthereumHash) extends OpenlawExecution {
   def message: String = executionStatus match {
-    case PendingExecution =>
-      "the transaction has been submitted, waiting for the transaction to be executed"
-    case SuccessfulExecution =>
-      "the transaction has been added to the chain and successfully executed"
+    case PendingExecution => "the transaction has been submitted, waiting for the transaction to be executed"
+    case SuccessfulExecution => "the transaction has been added to the chain and successfully executed"
     case FailedExecution => "the transaction execution has failed"
   }
 
-  def key: EthereumHash = tx
+  def key:EthereumHash = tx
 
-  override def typeIdentifier: String =
-    className[EthereumSmartContractExecution]
+  override def typeIdentifier: String = className[EthereumSmartContractExecution]
   override def serialize: Json = this.asJson
 }
 
 case object RequestIdentifier {
-  implicit val requestIdentifierEnc: Encoder[RequestIdentifier] =
-    (a: RequestIdentifier) => Json.fromString(a.identifier)
-  implicit val requestIdentifierDec: Decoder[RequestIdentifier] =
-    (c: HCursor) => c.as[String].map(RequestIdentifier(_))
+  implicit val requestIdentifierEnc: Encoder[RequestIdentifier] = (a: RequestIdentifier) => Json.fromString(a.identifier)
+  implicit val requestIdentifierDec: Decoder[RequestIdentifier] = (c: HCursor) => c.as[String].map(RequestIdentifier(_))
 
-  implicit val requestIdentifierEq: Eq[RequestIdentifier] =
-    Eq.fromUniversalEquals
+  implicit val requestIdentifierEq:Eq[RequestIdentifier] = Eq.fromUniversalEquals
 }
 
-final case class RequestIdentifier(identifier: String)
+final case class RequestIdentifier(identifier:String)
 
 object SuccessfulExternalCallExecution {
-  implicit val successfulExternalCallExecutionEnc
-    : Encoder[SuccessfulExternalCallExecution] = deriveEncoder
-  implicit val successfulExternalCallExecutionDec
-    : Decoder[SuccessfulExternalCallExecution] = deriveDecoder
+  implicit val successfulExternalCallExecutionEnc:Encoder[SuccessfulExternalCallExecution] = deriveEncoder
+  implicit val successfulExternalCallExecutionDec:Decoder[SuccessfulExternalCallExecution] = deriveDecoder
 }
 
-final case class SuccessfulExternalCallExecution(
-  scheduledDate: LocalDateTime,
-  executionDate: LocalDateTime,
-  result: String,
-  requestIdentifier: RequestIdentifier
-) extends ExternalCallExecution {
-  def message: String =
-    "the request has been added to the integrator queue and successfully executed"
+final case class SuccessfulExternalCallExecution(scheduledDate:LocalDateTime, executionDate:LocalDateTime, result: String, requestIdentifier: RequestIdentifier) extends ExternalCallExecution {
+  def message: String = "the request has been added to the integrator queue and successfully executed"
 
-  override def typeIdentifier: String =
-    className[SuccessfulExternalCallExecution]
+  override def typeIdentifier: String = className[SuccessfulExternalCallExecution]
   override def serialize: Json = this.asJson
   override def executionStatus: OpenlawExecutionStatus = SuccessfulExecution
 }
 
 object PendingExternalCallExecution {
-  implicit val pendingExternalCallExecutionEnc
-    : Encoder[PendingExternalCallExecution] = deriveEncoder
-  implicit val pendingExternalCallExecutionDec
-    : Decoder[PendingExternalCallExecution] = deriveDecoder
+  implicit val pendingExternalCallExecutionEnc:Encoder[PendingExternalCallExecution] = deriveEncoder
+  implicit val pendingExternalCallExecutionDec:Decoder[PendingExternalCallExecution] = deriveDecoder
 }
 
-final case class PendingExternalCallExecution(
-  scheduledDate: LocalDateTime,
-  executionDate: LocalDateTime,
-  requestIdentifier: RequestIdentifier
-) extends ExternalCallExecution {
-  def message: String =
-    "the request has been submitted, waiting for the request to be executed"
+final case class PendingExternalCallExecution(scheduledDate:LocalDateTime, executionDate:LocalDateTime, requestIdentifier: RequestIdentifier) extends ExternalCallExecution {
+  def message: String = "the request has been submitted, waiting for the request to be executed"
   override def typeIdentifier: String = className[PendingExternalCallExecution]
   override def serialize: Json = this.asJson
   override def executionStatus: OpenlawExecutionStatus = PendingExecution
 }
 
 object FailedExternalCallExecution {
-  implicit val failedExternalCallExecutionEnc
-    : Encoder[FailedExternalCallExecution] = deriveEncoder
-  implicit val failedExternalCallExecutionDec
-    : Decoder[FailedExternalCallExecution] = deriveDecoder
+  implicit val failedExternalCallExecutionEnc:Encoder[FailedExternalCallExecution] = deriveEncoder
+  implicit val failedExternalCallExecutionDec:Decoder[FailedExternalCallExecution] = deriveDecoder
 }
 
-final case class FailedExternalCallExecution(
-  scheduledDate: LocalDateTime,
-  executionDate: LocalDateTime,
-  errorMessage: String,
-  requestIdentifier: RequestIdentifier
-) extends ExternalCallExecution {
+final case class FailedExternalCallExecution(scheduledDate:LocalDateTime, executionDate:LocalDateTime, errorMessage: String, requestIdentifier: RequestIdentifier) extends ExternalCallExecution {
   def message: String = s"the request execution has failed. $errorMessage"
   override def typeIdentifier: String = className[FailedExternalCallExecution]
   override def serialize: Json = this.asJson
@@ -231,12 +157,12 @@ final case class FailedExternalCallExecution(
 }
 
 sealed trait ExternalCallExecution extends OpenlawExecution {
-  val requestIdentifier: RequestIdentifier
+  val requestIdentifier:RequestIdentifier
 
-  def key: String = requestIdentifier.identifier
+  def key:String = requestIdentifier.identifier
 }
 
-sealed abstract class OpenlawExecutionStatus(val name: String)
+sealed abstract class OpenlawExecutionStatus(val name:String)
 
 case object PendingExecution extends OpenlawExecutionStatus("pending")
 case object SuccessfulExecution extends OpenlawExecutionStatus("success")
@@ -244,62 +170,43 @@ case object FailedExecution extends OpenlawExecutionStatus("failed")
 
 object OpenlawExecutionStatus {
 
-  def apply(name: String): OpenlawExecutionStatus = name match {
+  def apply(name:String):OpenlawExecutionStatus = name match {
     case "success" => SuccessfulExecution
-    case "failed"  => FailedExecution
-    case _         => PendingExecution
+    case "failed" => FailedExecution
+    case _ => PendingExecution
   }
 
-  implicit val executionStatusDecoder: Decoder[OpenlawExecutionStatus] =
-    (c: HCursor) =>
-      for {
-        name <- c.as[String]
-      } yield OpenlawExecutionStatus(name)
+  implicit val executionStatusDecoder: Decoder[OpenlawExecutionStatus] = (c: HCursor) => for {
+      name <- c.as[String]
+    } yield OpenlawExecutionStatus(name)
 
-  implicit val executionStatusEncoder: Encoder[OpenlawExecutionStatus] =
-    (a: OpenlawExecutionStatus) => Json.fromString(a.name)
+  implicit val executionStatusEncoder: Encoder[OpenlawExecutionStatus] = (a: OpenlawExecutionStatus) => Json.fromString(a.name)
 
-  implicit val eqForExecutionStatus: Eq[OpenlawExecutionStatus] =
-    Eq.fromUniversalEquals
+  implicit val eqForExecutionStatus: Eq[OpenlawExecutionStatus] = Eq.fromUniversalEquals
 }
 
 trait ParameterType {
-  val typeParameter: VariableType
+  val typeParameter:VariableType
 }
 
 trait ParameterTypeProvider {
-  def createParameterInstance(
-    parameterType: VariableType
-  ): VariableType with ParameterType
+  def createParameterInstance(parameterType:VariableType):VariableType with ParameterType
 }
 
 abstract class VariableType(val name: String) {
 
   def serialize: Json = Json.obj("name" -> io.circe.Json.fromString(name))
 
-  def validateOperation(
-    expr: ValueExpression,
-    executionResult: TemplateExecutionResult
-  ): Result[Unit] = Success(())
+  def validateOperation(expr: ValueExpression, executionResult: TemplateExecutionResult): Result[Unit] = Success(())
 
-  def accessVariables(
-    name: VariableName,
-    keys: List[VariableMemberKey],
-    executionResult: TemplateExecutionResult
-  ): Result[List[VariableName]] =
+  def accessVariables(name:VariableName, keys:List[VariableMemberKey], executionResult: TemplateExecutionResult): Result[List[VariableName]] =
     Success(List(name))
 
-  def operationWith(rightType: VariableType,
-                    operation: ValueOperation): VariableType =
+  def operationWith(rightType: VariableType, operation: ValueOperation): VariableType =
     this
 
-  def access(
-    value: OpenlawValue,
-    variableName: VariableName,
-    keys: List[VariableMemberKey],
-    executionResult: TemplateExecutionResult
-  ): Result[Option[OpenlawValue]] = {
-    if (keys.isEmpty) {
+  def access(value: OpenlawValue, variableName:VariableName, keys: List[VariableMemberKey], executionResult:TemplateExecutionResult): Result[Option[OpenlawValue]] = {
+    if(keys.isEmpty) {
       Success(Some(value))
     } else {
       Failure(s"The variable $variableName of type $name has no properties")
@@ -311,144 +218,85 @@ abstract class VariableType(val name: String) {
   def checkTypeName(nameToCheck: String): Boolean =
     this.name.equalsIgnoreCase(nameToCheck)
 
-  def validateKeys(variableName: VariableName,
-                   keys: List[VariableMemberKey],
-                   expression: Expression,
-                   executionResult: TemplateExecutionResult): Result[Unit] =
-    keys.headOption
-      .map(
-        _ =>
-          Failure(s"The variable $variableName of type $name has no properties")
-      )
-      .getOrElse(Success(()))
+  def validateKeys(variableName:VariableName, keys:List[VariableMemberKey], expression:Expression, executionResult: TemplateExecutionResult): Result[Unit] =
+    keys.headOption.map(_ => Failure(s"The variable $variableName of type $name has no properties")).getOrElse(Success(()))
 
-  def keysType(keys: List[VariableMemberKey],
-               expression: Expression,
-               executionResult: TemplateExecutionResult): Result[VariableType] =
-    if (keys.nonEmpty) {
-      Failure(
-        s"the type $name has no properties (tried to access ${keys.mkString(".")})"
-      )
-    } else {
-      Success(thisType)
-    }
+  def keysType(keys: List[VariableMemberKey], expression: Expression, executionResult: TemplateExecutionResult):Result[VariableType] = if(keys.nonEmpty) {
+    Failure(s"the type $name has no properties (tried to access ${keys.mkString(".")})")
+  } else {
+    Success(thisType)
+  }
 
-  def combineConverted[U <: OpenlawValue, Y <: OpenlawValue](
-    optLeft: Option[OpenlawValue],
-    optRight: Option[OpenlawValue]
-  )(
-    operation: PartialFunction[(U#T, U#T), Result[Y]]
-  )(implicit ct: ClassTag[U]): Result[Option[Y]] =
+  def combineConverted[U <: OpenlawValue, Y <: OpenlawValue]
+    (optLeft: Option[OpenlawValue], optRight: Option[OpenlawValue])
+    (operation: PartialFunction[(U#T, U#T), Result[Y]])
+    (implicit ct: ClassTag[U])
+  : Result[Option[Y]] =
     combineConverted[U, U, Y](optLeft, optRight)(operation)
 
-  def combineConverted[U <: OpenlawValue, V <: OpenlawValue, Y <: OpenlawValue](
-    optLeft: Option[OpenlawValue],
-    optRight: Option[OpenlawValue]
-  )(
-    operation: PartialFunction[(U#T, V#T), Result[Y]]
-  )(implicit ct1: ClassTag[U], ct2: ClassTag[V]): Result[Option[Y]] = {
+  def combineConverted[U <: OpenlawValue, V <: OpenlawValue, Y <: OpenlawValue]
+    (optLeft: Option[OpenlawValue], optRight: Option[OpenlawValue])
+    (operation: PartialFunction[(U#T, V#T), Result[Y]])
+    (implicit ct1: ClassTag[U], ct2: ClassTag[V])
+  : Result[Option[Y]] = {
     (for {
       left <- EitherT(optLeft.map(VariableType.convert[U]))
       right <- EitherT(optRight.map(VariableType.convert[V]))
     } yield {
       if (operation.isDefinedAt(left -> right)) operation(left -> right)
-      else
-        Failure(
-          s"no matching case in partial function for arguments $left and $right"
-        )
-    }).value
+      else Failure(s"no matching case in partial function for arguments $left and $right")
+    })
+      .value
       .map(_.flatten)
       .sequence
   }
 
-  def combine[Y <: OpenlawValue](optLeft: Option[OpenlawValue],
-                                 optRight: Option[OpenlawValue])(
-    operation: PartialFunction[(OpenlawValue, OpenlawValue), Result[Y]]
-  ): Result[Option[Y]] = {
+  def combine[Y <: OpenlawValue](optLeft: Option[OpenlawValue], optRight: Option[OpenlawValue])(operation: PartialFunction[(OpenlawValue, OpenlawValue), Result[Y]]): Result[Option[Y]] = {
     (for {
       left <- optLeft
       right <- optRight
     } yield {
       if (operation.isDefinedAt(left -> right)) operation(left -> right)
-      else
-        Failure(
-          s"no matching case in partial function for arguments $left and $right"
-        )
-    }).sequence
+      else Failure(s"no matching case in partial function for arguments $left and $right")
+    })
+      .sequence
   }
 
-  def plus(
-    optLeft: Option[OpenlawValue],
-    optRight: Option[OpenlawValue],
-    executionResult: TemplateExecutionResult
-  ): Result[Option[OpenlawValue]] =
-    Failure(
-      new UnsupportedOperationException(s"$name type does not support addition")
-    )
-  def minus(
-    optLeft: Option[OpenlawValue],
-    optRight: Option[OpenlawValue],
-    executionResult: TemplateExecutionResult
-  ): Result[Option[OpenlawValue]] =
-    Failure(
-      new UnsupportedOperationException(
-        s"$name type does not support substraction"
-      )
-    )
-  def multiply(
-    optLeft: Option[OpenlawValue],
-    optRight: Option[OpenlawValue],
-    executionResult: TemplateExecutionResult
-  ): Result[Option[OpenlawValue]] =
-    Failure(
-      new UnsupportedOperationException(
-        s"$name type does not support multiplication"
-      )
-    )
-  def divide(
-    optLeft: Option[OpenlawValue],
-    optRight: Option[OpenlawValue],
-    executionResult: TemplateExecutionResult
-  ): Result[Option[OpenlawValue]] =
-    Failure(
-      new UnsupportedOperationException(s"$name type does not support division")
-    )
+  def plus(optLeft: Option[OpenlawValue], optRight: Option[OpenlawValue], executionResult: TemplateExecutionResult): Result[Option[OpenlawValue]] =
+    Failure(new UnsupportedOperationException(s"$name type does not support addition"))
+  def minus(optLeft: Option[OpenlawValue], optRight: Option[OpenlawValue], executionResult: TemplateExecutionResult): Result[Option[OpenlawValue]] =
+    Failure(new UnsupportedOperationException(s"$name type does not support substraction"))
+  def multiply(optLeft: Option[OpenlawValue], optRight: Option[OpenlawValue], executionResult: TemplateExecutionResult): Result[Option[OpenlawValue]] =
+    Failure(new UnsupportedOperationException(s"$name type does not support multiplication"))
+  def divide(optLeft: Option[OpenlawValue], optRight: Option[OpenlawValue], executionResult: TemplateExecutionResult): Result[Option[OpenlawValue]] =
+    Failure(new UnsupportedOperationException(s"$name type does not support division"))
 
-  def isCompatibleType(otherType: VariableType,
-                       operation: ValueOperation): Boolean =
+  def isCompatibleType(otherType: VariableType, operation: ValueOperation): Boolean =
     otherType === this
 
-  def cast(value: String,
-           executionResult: TemplateExecutionResult): Result[OpenlawValue]
+  def cast(value: String, executionResult:TemplateExecutionResult):Result[OpenlawValue]
 
-  def missingValueFormat(name: String): List[AgreementElement] =
-    List(FreeText(Text(s"[[${name}]]")))
+  def missingValueFormat(name: String): List[AgreementElement] = List(FreeText(Text(s"[[${name}]]")))
 
   def internalFormat(value: OpenlawValue): Result[String]
 
-  def construct(
-    constructorParams: Parameter,
-    executionResult: TemplateExecutionResult
-  ): Result[Option[OpenlawValue]] = constructorParams match {
-    case OneValueParameter(expr) =>
-      expr.evaluate(executionResult)
-    case Parameters(parameterMap) =>
-      parameterMap.toMap.get("value") match {
-        case Some(parameter) =>
-          construct(parameter, executionResult)
-        case None => Success(None)
-      }
-    case _ =>
-      Failure(s"the constructor for $name only handles single values")
-  }
+  def construct(constructorParams: Parameter, executionResult: TemplateExecutionResult): Result[Option[OpenlawValue]] = constructorParams match {
+      case OneValueParameter(expr) =>
+        expr.evaluate(executionResult)
+      case Parameters(parameterMap) =>
+        parameterMap.toMap.get("value") match {
+          case Some(parameter) =>
+            construct(parameter, executionResult)
+          case None => Success(None)
+        }
+      case _ =>
+        Failure(s"the constructor for $name only handles single values")
+    }
 
   def defaultFormatter: Formatter =
     new DefaultFormatter
 
-  def getFormatter(
-    name: FormatterDefinition,
-    executionResult: TemplateExecutionResult
-  ): Result[Formatter] = Success(defaultFormatter)
+  def getFormatter(name:FormatterDefinition, executionResult:TemplateExecutionResult): Result[Formatter] = Success(defaultFormatter)
 
   def getSingleParameter(constructorParams: Parameter): Result[Expression] =
     constructorParams match {
@@ -459,91 +307,76 @@ abstract class VariableType(val name: String) {
 
   def handleTry[T](thisTry: Try[T]): T =
     thisTry match {
-      case scala.util.Success(v)  => v
+      case scala.util.Success(v) => v
       case scala.util.Failure(ex) => throw ex
     }
 
-  def thisType: VariableType
+  def thisType:VariableType
 
-  def getExpression(params: Map[String, Parameter],
-                    names: String*): Result[Expression] =
-    getParameter(params, names: _*)
+  def getExpression(params:Map[String,Parameter], names:String*): Result[Expression] =
+    getParameter(params, names:_*)
       .map(getExpression)
       .sequence
       .flatMap {
         case Some(expr) => Success(expr)
-        case None =>
-          Failure(
-            s"parameter $name not found. available parameters: ${params.keys.mkString(",")}"
-          )
+        case None => Failure(s"parameter $name not found. available parameters: ${params.keys.mkString(",")}")
       }
 
-  def getParameter(params: Map[String, Parameter],
-                   names: String*): Option[Parameter] =
+  def getParameter(params:Map[String,Parameter], names:String*):Option[Parameter] =
     names.flatMap(params.get).headOption
 
-  def getExpression(param: Parameter): Result[Expression] = param match {
+  def getExpression(param:Parameter): Result[Expression] = param match {
     case OneValueParameter(expr) => Success(expr)
-    case _ =>
-      Failure(
-        "invalid parameter type " + param.getClass.getSimpleName + " expecting single expression"
-      )
+    case _ => Failure("invalid parameter type " + param.getClass.getSimpleName + " expecting single expression")
   }
 
-  def format(
-    formatter: Option[FormatterDefinition],
-    value: OpenlawValue,
-    executionResult: TemplateExecutionResult
-  ): Result[List[AgreementElement]] =
+  def format(formatter:Option[FormatterDefinition], value:OpenlawValue, executionResult: TemplateExecutionResult): Result[List[AgreementElement]] =
     formatter
       .map(getFormatter(_, executionResult))
       .getOrElse(Success(defaultFormatter))
       .flatMap(_.format(value, executionResult))
 
-  def getMandatoryParameter(name: String,
-                            parameter: Parameters): Result[Parameter] = {
+  def getMandatoryParameter(name:String, parameter:Parameters): Result[Parameter] = {
     parameter.parameterMap.toMap.get(name) match {
       case Some(param) => Success(param)
-      case None        => Failure(s"mandatory parameter $name could not be found")
+      case None => Failure(s"mandatory parameter $name could not be found")
     }
   }
 }
 
 object VariableType {
 
-  def allTypes(): List[VariableType] =
-    List(
-      AbstractCollectionType,
-      AbstractFunctionType,
-      OLOwnType,
-      AddressType,
-      ChoiceType,
-      ClauseType,
-      DateType,
-      DateTimeType,
-      AbstractDomainType,
-      EthAddressType,
-      EthTxHashType,
-      EthereumCallType,
-      EthereumEventFilterType,
-      ExternalCallType,
-      ExternalSignatureType,
-      ExternalStorageType,
-      IdentityType,
-      LargeTextType,
-      LinkType,
-      ImageType,
-      NumberType,
-      PeriodType,
-      SectionType,
-      SmartContractMetadataType,
-      AbstractStructureType,
-      TemplateType,
-      TextType,
-      ValidationType,
-      RegexType,
-      YesNoType
-    )
+  def allTypes():List[VariableType] = List(
+    AbstractCollectionType,
+    AbstractFunctionType,
+    OLOwnType,
+    AddressType,
+    ChoiceType,
+    ClauseType,
+    DateType,
+    DateTimeType,
+    AbstractDomainType,
+    EthAddressType,
+    EthTxHashType,
+    EthereumCallType,
+    EthereumEventFilterType,
+    ExternalCallType,
+    ExternalSignatureType,
+    ExternalStorageType,
+    IdentityType,
+    LargeTextType,
+    LinkType,
+    ImageType,
+    NumberType,
+    PeriodType,
+    SectionType,
+    SmartContractMetadataType,
+    AbstractStructureType,
+    TemplateType,
+    TextType,
+    ValidationType,
+    RegexType,
+    YesNoType)
 
   def getByName(name: String): Option[VariableType] =
     allTypes().find(_.name === name)
@@ -551,50 +384,28 @@ object VariableType {
   implicit val eqForVariableType: Eq[VariableType] =
     (x: VariableType, y: VariableType) => x == y
 
-  def getPeriod(v: Expression,
-                executionResult: TemplateExecutionResult): Result[Period] =
-    get(v, executionResult, PeriodType.cast)
-  def getEthereumAddress(
-    v: Expression,
-    executionResult: TemplateExecutionResult
-  ): Result[EthereumAddress] =
-    get(v, executionResult, EthAddressType.cast)
-  def getDate(
-    v: Expression,
-    executionResult: TemplateExecutionResult
-  ): Result[OpenlawDateTime] =
-    get(v, executionResult, DateTimeType.cast)
-  def getMetadata(
-    v: Expression,
-    executionResult: TemplateExecutionResult
-  ): Result[SmartContractMetadata] =
-    get(v, executionResult, SmartContractMetadataType.cast)
-  def getString(v: Expression,
-                executionResult: TemplateExecutionResult): Result[String] =
-    get[OpenlawString](v, executionResult, (str, _) => Success(str))
-      .map(_.underlying)
+  def getPeriod(v: Expression, executionResult: TemplateExecutionResult): Result[Period] =
+    get(v,executionResult, PeriodType.cast)
+  def getEthereumAddress(v: Expression, executionResult: TemplateExecutionResult): Result[EthereumAddress] =
+    get(v,executionResult,EthAddressType.cast)
+  def getDate(v: Expression, executionResult: TemplateExecutionResult): Result[OpenlawDateTime] =
+    get(v,executionResult, DateTimeType.cast)
+  def getMetadata(v: Expression, executionResult: TemplateExecutionResult): Result[SmartContractMetadata] =
+    get(v,executionResult,SmartContractMetadataType.cast)
+  def getString(v: Expression, executionResult: TemplateExecutionResult): Result[String] =
+    get[OpenlawString](v,executionResult, (str,_) => Success(str)).map(_.underlying)
 
-  def get[T <: OpenlawValue](
-    expr: Expression,
-    executionResult: TemplateExecutionResult,
-    cast: (String, TemplateExecutionResult) => Result[T]
-  )(implicit classTag: ClassTag[T]): Result[T] =
+  def get[T <: OpenlawValue](expr: Expression, executionResult: TemplateExecutionResult, cast: (String,TemplateExecutionResult) => Result[T])(implicit classTag: ClassTag[T]): Result[T] =
     expr
       .evaluate(executionResult)
       .flatMap {
-        case Some(value: T) => Success(value)
-        case Some(value: OpenlawString) =>
-          cast(value.underlying, executionResult)
-        case Some(value) =>
-          Failure(
-            "cannot get value of type " + value.getClass.getSimpleName + ". expecting " + classTag.runtimeClass.getSimpleName
-          )
+        case Some(value:T) => Success(value)
+        case Some(value:OpenlawString) => cast(value.underlying, executionResult)
+        case Some(value) => Failure("cannot get value of type " + value.getClass.getSimpleName + ". expecting " + classTag.runtimeClass.getSimpleName)
         case None => Failure("could not get the value. Missing data")
       }
 
-  def convert[U <: OpenlawValue](
-    value: OpenlawValue
-  )(implicit classTag: ClassTag[U]): Result[U#T] = value match {
+  def convert[U <: OpenlawValue](value:OpenlawValue)(implicit classTag: ClassTag[U]): Result[U#T] = value match {
     case convertedValue: U =>
       Success(convertedValue.underlying)
     case other =>
@@ -609,46 +420,26 @@ object VariableType {
   implicit val variableTypeEnc: Encoder[VariableType] = (a: VariableType) =>
     a.serialize
 
-  implicit val variableTypeDec: Decoder[VariableType] = (c: HCursor) =>
-    c.downField("name")
-      .as[String]
-      .flatMap(
-        name =>
-          VariableType.allTypes().find(_.name === name) match {
-            case Some(varType) => Right(varType)
-            case None          => createCustomType(c, name)
-        }
-    )
+  implicit val variableTypeDec: Decoder[VariableType] = (c: HCursor) => c.downField("name").as[String]
+    .flatMap(name => VariableType.allTypes().find(_.name === name) match {
+        case Some(varType) => Right(varType)
+        case None => createCustomType(c, name)
+      })
 
-  private def createCustomType(cursor: HCursor,
-                               name: String): Decoder.Result[VariableType] = {
+  private def createCustomType(cursor: HCursor, name:String):Decoder.Result[VariableType] = {
     DefinedStructureType.definedStructureTypeDec(cursor) match {
       case Right(value) => Right(value)
-      case Left(_) =>
-        DefinedChoiceType.definedChoiceTypeDec(cursor) match {
-          case Right(value) => Right(value)
-          case Left(_) =>
-            Left(
-              DecodingFailure(
-                s"unknown type $name. or error while decoding",
-                Nil
-              )
-            )
-        }
+      case Left(_) => DefinedChoiceType.definedChoiceTypeDec(cursor) match {
+        case Right(value) => Right(value)
+        case Left(_) => Left(DecodingFailure(s"unknown type $name. or error while decoding", Nil))
+      }
     }
     DefinedDomainType.definedDomainTypeDec(cursor) match {
       case Right(value) => Right(value)
-      case Left(_) =>
-        DefinedChoiceType.definedChoiceTypeDec(cursor) match {
-          case Right(value) => Right(value)
-          case Left(_) =>
-            Left(
-              DecodingFailure(
-                s"unknown type $name. or error while decoding",
-                Nil
-              )
-            )
-        }
+      case Left(_) => DefinedChoiceType.definedChoiceTypeDec(cursor) match {
+        case Right(value) => Right(value)
+        case Left(_) => Left(DecodingFailure(s"unknown type $name. or error while decoding", Nil))
+      }
     }
   }
 }
@@ -657,23 +448,19 @@ object LocalDateTimeHelper {
   implicit val dateDecoder: Decoder[LocalDateTime] = (c: HCursor) => {
     for {
       epoch <- c.as[Long]
-    } yield LocalDateTime.ofEpochSecond(epoch, 0, ZoneOffset.UTC)
+    } yield LocalDateTime.ofEpochSecond(epoch, 0,ZoneOffset.UTC)
   }
-  implicit val dateEncoder: Encoder[Clock] = (a: Clock) =>
-    Json.fromString(a.getZone.getId)
+  implicit val dateEncoder: Encoder[Clock] = (a: Clock) => Json.fromString(a.getZone.getId)
 
   implicit val clockDecoder: Decoder[Clock] = (c: HCursor) => {
     for {
       zoneId <- c.as[String]
     } yield Clock.system(ZoneId.of(zoneId))
   }
-  implicit val clockEncoder: Encoder[LocalDateTime] = (a: LocalDateTime) =>
-    Json.fromLong(a.toEpochSecond(ZoneOffset.UTC))
+  implicit val clockEncoder: Encoder[LocalDateTime] = (a: LocalDateTime) => Json.fromLong(a.toEpochSecond(ZoneOffset.UTC))
   implicit val eqForLocalDateTime: Eq[LocalDateTime] = Eq.fromUniversalEquals
 
-  implicit val dateKeyEncoder: KeyEncoder[LocalDateTime] =
-    (key: LocalDateTime) => key.toEpochSecond(ZoneOffset.UTC).toString
+  implicit val dateKeyEncoder:KeyEncoder[LocalDateTime] = (key: LocalDateTime) => key.toEpochSecond(ZoneOffset.UTC).toString
 
-  implicit val dateKeyDecoder: KeyDecoder[LocalDateTime] = (key: String) =>
-    Try(LocalDateTime.ofEpochSecond(key.toLong, 0, ZoneOffset.UTC)).toOption
+  implicit val dateKeyDecoder:KeyDecoder[LocalDateTime] = (key: String) => Try(LocalDateTime.ofEpochSecond(key.toLong, 0, ZoneOffset.UTC)).toOption
 }

--- a/shared/src/test/scala/org/adridadou/openlaw/parser/OpenlawTemplateLanguageParserSpec.scala
+++ b/shared/src/test/scala/org/adridadou/openlaw/parser/OpenlawTemplateLanguageParserSpec.scala
@@ -32,7 +32,7 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
 
   private val emptyExecutionResult = OpenlawExecutionState(
     parameters = TemplateParameters(),
-    id = TemplateExecutionResultId(s"@@anonymous_main_template_id@@"),
+    id = TemplateExecutionResultId("@@anonymous_main_template_id@@"),
     info = OLInformation(),
     template = CompiledAgreement(),
     executions = Map(),
@@ -1027,7 +1027,7 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
       case Left(ex) =>
         ex.message shouldEqual "alias expression uses undefined variables b"
       case Right(_) =>
-        fail(s"this should fail")
+        fail("this should fail")
     }
   }
 
@@ -1039,7 +1039,7 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
       case Left(ex) =>
         ex.message shouldEqual "error while processing the new variable var2. The variable \"var3\" is used in the constructor but has not been defined"
       case Right(_) =>
-        fail(s"this should fail")
+        fail("this should fail")
     }
   }
 

--- a/shared/src/test/scala/org/adridadou/openlaw/parser/OpenlawTemplateLanguageParserSpec.scala
+++ b/shared/src/test/scala/org/adridadou/openlaw/parser/OpenlawTemplateLanguageParserSpec.scala
@@ -2438,4 +2438,87 @@ here""".stripMargin
     }
   }
 
+  it should "not create a new variable type ExternalStorage when arguments are missing" in {
+    val textMissingFile =
+      """
+        |[[Dropbox Storage: ExternalStorage(serviceName:"Dropbox")]]
+        |Test simple template
+      """.stripMargin
+
+    executeTemplate(
+      textMissingFile,
+      Map(),
+      Map(),
+      Map(
+        ServiceName("Dropbox") -> IntegratedServiceDefinition.signatureDefinition
+      )
+    ) match {
+      case Right(executionResult) =>
+        fail("Variable should not be created when arguments are missing")
+      case Failure(ex, message) =>
+        message shouldBe "parameter ExternalStorage not found. available parameters: serviceName"
+    }
+
+  }
+
+  it should "not create a new variable type ExternalStorage if file type is not supported" in {
+    val textMissingFile =
+      """
+        |[[Dropbox Storage: ExternalStorage(serviceName:"Dropbox"; txt: "/storage/files/myFile.txt")]]
+        |Test simple template
+      """.stripMargin
+
+    executeTemplate(
+      textMissingFile,
+      Map(),
+      Map(),
+      Map(
+        ServiceName("Dropbox") -> IntegratedServiceDefinition.signatureDefinition
+      )
+    ) match {
+      case Right(executionResult) =>
+        fail("Variable should not be created when arguments are missing")
+      case Failure(ex, message) =>
+        message shouldBe "parameter ExternalStorage not found. available parameters: serviceName,txt"
+    }
+  }
+
+  it should "create new ExternalStorage variable for each supported file" in {
+    val textMissingFile =
+      """
+        |[[PDF Storage: ExternalStorage(serviceName:"Dropbox"; pdf: "/storage/files/myFile.pdf")]]
+        |[[DOC Storage: ExternalStorage(serviceName:"Dropbox"; doc: "/storage/files/myFile.doc")]]
+        |[[DOCX Storage: ExternalStorage(serviceName:"Dropbox"; docx: "/storage/files/myFile.docx")]]
+        |[[RTF Storage: ExternalStorage(serviceName:"Dropbox"; rtf: "/storage/files/myFile.rtf")]]
+        |[[ODT Storage: ExternalStorage(serviceName:"Dropbox"; odt: "/storage/files/myFile.odt")]]
+        |Test simple template
+      """.stripMargin
+
+    executeTemplate(
+      textMissingFile,
+      Map(),
+      Map(),
+      Map(
+        ServiceName("Dropbox") -> IntegratedServiceDefinition.signatureDefinition
+      )
+    ) match {
+      case Right(executionResult) =>
+        val Success(validationResult) = executionResult.validateExecution
+        validationResult.validationExpressionErrors shouldBe Seq()
+        val storages = executionResult
+          .getVariableValues[ExternalStorage](ExternalStorageType)
+          .getOrThrow()
+        storages.flatMap(s => s.filePath.path) shouldBe List(
+          "/storage/files/myFile.pdf",
+          "/storage/files/myFile.doc",
+          "/storage/files/myFile.docx",
+          "/storage/files/myFile.rtf",
+          "/storage/files/myFile.odt"
+        )
+
+      case Failure(ex, message) =>
+        fail(message, ex)
+    }
+  }
+
 }

--- a/shared/src/test/scala/org/adridadou/openlaw/parser/OpenlawTemplateLanguageParserSpec.scala
+++ b/shared/src/test/scala/org/adridadou/openlaw/parser/OpenlawTemplateLanguageParserSpec.scala
@@ -8,11 +8,7 @@ import org.adridadou.openlaw.parser.contract.ParagraphEdits
 import org.adridadou.openlaw.parser.template._
 import org.adridadou.openlaw.parser.template.variableTypes._
 import org.adridadou.openlaw.result.{Failure, Result, Success}
-import org.adridadou.openlaw.result.Implicits.{
-  RichResult,
-  RichResultNel,
-  failureCause2Exception
-}
+import org.adridadou.openlaw.result.Implicits.{RichResult, RichResultNel, failureCause2Exception}
 import org.adridadou.openlaw.values.TemplateParameters
 import org.adridadou.openlaw.vm.OpenlawExecutionEngine
 import org.scalatest._
@@ -30,113 +26,71 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
   private val service = new OpenlawTemplateLanguageParserService(clock)
   private val engine = new OpenlawExecutionEngine
 
-  private val emptyExecutionResult = OpenlawExecutionState(
-    parameters = TemplateParameters(),
-    id = TemplateExecutionResultId("@@anonymous_main_template_id@@"),
-    info = OLInformation(),
-    template = CompiledAgreement(),
-    executions = Map(),
-    anonymousVariableCounter = new AtomicInteger(0),
-    executionType = TemplateExecution,
-    variableRedefinition = VariableRedefinition(),
-    remainingElements = mutable.Buffer(),
-    clock = clock
-  )
+	private val emptyExecutionResult = OpenlawExecutionState(
+		parameters = TemplateParameters(),
+		id = TemplateExecutionResultId(s"@@anonymous_main_template_id@@"),
+		info = OLInformation(),
+		template = CompiledAgreement(),
+		executions = Map(),
+		anonymousVariableCounter = new AtomicInteger(0),
+		executionType = TemplateExecution,
+		variableRedefinition = VariableRedefinition(),
+		remainingElements = mutable.Buffer(),
+		clock = clock
+	)
 
-  private def structureAgreement(
-    text: String,
-    p: Map[String, String] = Map(),
-    templates: Map[TemplateSourceIdentifier, CompiledTemplate] = Map(),
-    externalCallStructures: Map[ServiceName, IntegratedServiceDefinition] =
-      Map()
-  ): Result[StructuredAgreement] =
-    compiledTemplate(text).flatMap({
-      case agreement: CompiledAgreement =>
-        val params = p.map({ case (k, v) => VariableName(k) -> v })
-        engine
-          .execute(
-            agreement,
-            TemplateParameters(params),
-            templates,
-            externalCallStructures
-          )
-          .flatMap(agreement.structuredMainTemplate)
-      case _ =>
-        Failure("was expecting agreement")
-    })
+  private def structureAgreement(text:String, p:Map[String, String] = Map(), templates:Map[TemplateSourceIdentifier, CompiledTemplate] = Map(), externalCallStructures: Map[ServiceName, IntegratedServiceDefinition] = Map()):Result[StructuredAgreement] = compiledTemplate(text).flatMap({
+    case agreement:CompiledAgreement =>
+      val params = p.map({case (k,v) => VariableName(k) -> v})
+      engine.execute(agreement, TemplateParameters(params), templates, externalCallStructures).flatMap(agreement.structuredMainTemplate)
+    case _ =>
+      Failure("was expecting agreement")
+  })
 
-  private def executeTemplate(
-    text: String,
-    p: Map[String, String] = Map(),
-    templates: Map[TemplateSourceIdentifier, CompiledTemplate] = Map(),
-    externalCallStructures: Map[ServiceName, IntegratedServiceDefinition] =
-      Map()
-  ): Result[OpenlawExecutionState] =
-    compiledTemplate(text).flatMap({
-      case agreement: CompiledAgreement =>
-        val params = p.map({ case (k, v) => VariableName(k) -> v })
-        engine.execute(
-          agreement,
-          TemplateParameters(params),
-          templates,
-          externalCallStructures = externalCallStructures
-        )
-      case _ =>
-        Failure("was expecting agreement")
-    })
+  private def executeTemplate(text:String, p:Map[String, String] = Map(), templates:Map[TemplateSourceIdentifier, CompiledTemplate] = Map(), externalCallStructures: Map[ServiceName, IntegratedServiceDefinition] = Map()):Result[OpenlawExecutionState] = compiledTemplate(text).flatMap({
+    case agreement:CompiledAgreement =>
+      val params = p.map({case (k,v) => VariableName(k) -> v})
+      engine.execute(agreement, TemplateParameters(params), templates, externalCallStructures = externalCallStructures)
+    case _ =>
+      Failure("was expecting agreement")
+  })
 
-  private def compiledTemplate(text: String): Result[CompiledTemplate] =
-    service.compileTemplate(text)
+  private def compiledTemplate(text:String): Result[CompiledTemplate] = service.compileTemplate(text)
 
-  private def compiledAgreement(text: String): Result[CompiledAgreement] =
-    compiledTemplate(text) match {
-      case Right(agreement: CompiledAgreement) => Right(agreement)
-      case Right(_)                            => Failure("was expecting agreement")
-      case Left(ex)                            => Failure(ex)
-    }
+  private def compiledAgreement(text:String): Result[CompiledAgreement] = compiledTemplate(text) match {
+    case Right(agreement:CompiledAgreement) => Right(agreement)
+    case Right(_) => Failure("was expecting agreement")
+    case Left(ex) => Failure(ex)
+  }
 
-  private def forReview(
-    text: String,
-    params: Map[String, String] = Map(),
-    paragraphs: ParagraphEdits = ParagraphEdits(Map())
-  ): Result[String] =
-    structureAgreement(text, params).map(service.forReview(_, paragraphs))
-  private def forPreview(
-    text: String,
-    params: Map[String, String] = Map(),
-    paragraphs: ParagraphEdits = ParagraphEdits(Map())
-  ): Result[String] =
-    structureAgreement(text, params).map(service.forPreview(_, paragraphs))
+  private def forReview(text:String, params:Map[String, String] = Map(), paragraphs:ParagraphEdits = ParagraphEdits(Map())):Result[String] =
+    structureAgreement(text,params).map(service.forReview(_, paragraphs))
+  private def forPreview(text:String, params:Map[String, String] = Map(), paragraphs:ParagraphEdits = ParagraphEdits(Map())):Result[String] =
+    structureAgreement(text,params).map(service.forPreview(_, paragraphs))
 
-  private def resultShouldBe(result: Result[String], expected: String): Unit =
-    result match {
-      case Right(actual) if actual === expected =>
-      case Right(actual) =>
-        throw new RuntimeException(s"$actual should be $expected")
-      case Failure(e, message) => throw new RuntimeException(e)
-    }
+  private def resultShouldBe(result:Result[String], expected:String): Unit = result match {
+    case Right(actual) if actual === expected =>
+    case Right(actual) => throw new RuntimeException(s"$actual should be $expected")
+    case Failure(e, message) => throw new RuntimeException(e)
+  }
 
   "Markdown parser service" should "handle tables" in {
-    val text =
+    val text=
       """| head1 | head2 | head3 |
          | ----- | ----- | ----- |
          | val11 | val12 | val13 |
          | val21 | val22 | val23 |"""
 
     val template = service.compileTemplate(text).right.value
-    template shouldBe a[CompiledAgreement]
+    template shouldBe a [CompiledAgreement]
 
-    val tableElement =
-      structureAgreement(text).map(_.paragraphs.head.elements.head).right.value
-    tableElement shouldBe a[TableElement]
-    resultShouldBe(
-      forReview(text),
-      """<p class="no-section"><table class="markdown-table"><tr class="markdown-table-row"><th class="markdown-table-header">head1</th><th class="markdown-table-header">head2</th><th class="markdown-table-header">head3</th></tr><tr class="markdown-table-row"><td class="markdown-table-data">val11</td><td class="markdown-table-data">val12</td><td class="markdown-table-data">val13</td></tr><tr class="markdown-table-row"><td class="markdown-table-data">val21</td><td class="markdown-table-data">val22</td><td class="markdown-table-data">val23</td></tr></table></p>"""
-    )
+    val tableElement = structureAgreement(text).map(_.paragraphs.head.elements.head).right.value
+    tableElement shouldBe a [TableElement]
+    resultShouldBe(forReview(text), """<p class="no-section"><table class="markdown-table"><tr class="markdown-table-row"><th class="markdown-table-header">head1</th><th class="markdown-table-header">head2</th><th class="markdown-table-header">head3</th></tr><tr class="markdown-table-row"><td class="markdown-table-data">val11</td><td class="markdown-table-data">val12</td><td class="markdown-table-data">val13</td></tr><tr class="markdown-table-row"><td class="markdown-table-data">val21</td><td class="markdown-table-data">val22</td><td class="markdown-table-data">val23</td></tr></table></p>""")
   }
 
   it should "handle tables following other elements" in {
-    val text =
+    val text=
       """This is a test.
     || head1 | head2 | head3 |
     || ----- | ----- | ----- |
@@ -145,14 +99,11 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
     |""".stripMargin
 
     val structure = structureAgreement(text)
-    structure
-      .map(_.paragraphs.head.elements(1))
-      .right
-      .value shouldBe a[TableElement]
-  }
+    structure.map(_.paragraphs.head.elements(1)).right.value shouldBe a [TableElement]
+   }
 
-  it should "handle tables mixed with other elements with pipes" in {
-    val text =
+   it should "handle tables mixed with other elements with pipes" in {
+    val text=
       """This is | a test.
     || head1 | head2 | head3 |
     || ----- | ----- | ----- |
@@ -160,15 +111,13 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
     || val21 | val22 | val23 |
     |This is a test.""".stripMargin
 
+
     val structure = structureAgreement(text)
-    structure
-      .map(_.paragraphs.head.elements(3))
-      .right
-      .value shouldBe a[TableElement]
-  }
+    structure.map(_.paragraphs.head.elements(3)).right.value shouldBe a [TableElement]
+   }
 
   it should "handle tables with variables in cells" in {
-    val text =
+    val text=
       """This is | a test.
     || head1 | head2 | head3 |
     || ----- | ----- | ----- |
@@ -176,18 +125,15 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
     || val21 | val22 | val23 |
     |This is a test.""".stripMargin
 
-    structureAgreement(text)
-      .map(_.paragraphs.head.elements(3))
-      .right
-      .value match {
-      case tableElement: TableElement =>
-        tableElement.rows.head.head.head shouldBe a[VariableElement]
-      case _ => fail("not a table element!")
-    }
-  }
+		structureAgreement(text).map(_.paragraphs.head.elements(3)).right.value match {
+			case tableElement:TableElement =>
+				tableElement.rows.head.head.head shouldBe a [VariableElement]
+			case _ => fail("not a table element!")
+		}
+   }
 
   it should "handle tables with variables in multiple rows" in {
-    val text =
+    val text=
       """This is | a test.
     || head1 | head2 | head3 |
     || ----- | ----- | ----- |
@@ -197,22 +143,19 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
     || val41 | val42 | val43 |
     |This is a test.""".stripMargin
 
-    structureAgreement(text)
-      .map(_.paragraphs.head.elements(3))
-      .right
-      .value match {
-      case tableElement: TableElement =>
-        tableElement.rows.head.head.head shouldBe a[VariableElement]
-        tableElement.rows(1).head.head should not be a[VariableElement]
-        tableElement.rows(2).head.head shouldBe a[VariableElement]
-        tableElement.rows(3).head.head should not be a[VariableElement]
-      case _ => fail("not a table element!")
-    }
+    structureAgreement(text).map(_.paragraphs.head.elements(3)).right.value match {
+			case tableElement:TableElement =>
+				tableElement.rows.head.head.head shouldBe a [VariableElement]
+				tableElement.rows(1).head.head should not be a[VariableElement]
+				tableElement.rows(2).head.head shouldBe a [VariableElement]
+				tableElement.rows(3).head.head should not be a[VariableElement]
+			case _ => fail("not a table element!")
+		}
 
-  }
+   }
 
   it should "handle tables with conditionals in cells" in {
-    val text =
+    val text=
       """This is | a test.
     || head1 | head2 | head3 |
     || ----- | ----- | ----- |
@@ -220,122 +163,78 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
     || val21 | val22 | val23 |
     |This is a test.""".stripMargin
 
-    structureAgreement(text, Map("conditional1" -> "true"))
-      .map(_.paragraphs.head.elements(3))
-      .right
-      .value match {
-      case tableElement: TableElement =>
-        tableElement.rows.head.head.head shouldBe a[ConditionalStart]
-      case _ => fail("not table element!")
-    }
+    structureAgreement(text, Map("conditional1" -> "true")).map(_.paragraphs.head.elements(3)).right.value match {
+			case tableElement:TableElement =>
+				tableElement.rows.head.head.head shouldBe a [ConditionalStart]
+			case _ => fail("not table element!")
+		}
 
-  }
+   }
 
   it should "parse and replace each variable with its value" in {
 
-    val clauseText =
-      "This is my clause. [[contractor]]. And I am born in [[contractorBirthdate]]"
+    val clauseText = "This is my clause. [[contractor]]. And I am born in [[contractorBirthdate]]"
 
-    resultShouldBe(
-      forReview(
-        clauseText,
-        Map(
-          "contractor" -> "My contractor name",
-          "contractorBirthdate" -> "January 13th 1983"
-        )
-      ),
-      """<p class="no-section">This is my clause. My contractor name. And I am born in January 13th 1983</p>"""
-    )
+
+    resultShouldBe(forReview(clauseText, Map(
+      "contractor" -> "My contractor name",
+      "contractorBirthdate" -> "January 13th 1983"
+    )), """<p class="no-section">This is my clause. My contractor name. And I am born in January 13th 1983</p>""")
   }
 
   it should "compile the document and the compiled version can be then parsed" in {
-    val clauseText =
-      "This is my clause. [[contractor]]. And I am born in [[contractorBirthdate]]"
+    val clauseText = "This is my clause. [[contractor]]. And I am born in [[contractorBirthdate]]"
     val parameters = Map(
       "contractor" -> "My contractor name",
-      "contractorBirthdate" -> "January 13th 1983"
-    )
+      "contractorBirthdate" -> "January 13th 1983")
 
-    resultShouldBe(
-      forReview(clauseText, parameters),
-      """<p class="no-section">This is my clause. My contractor name. And I am born in January 13th 1983</p>"""
-    )
+
+    resultShouldBe(forReview(clauseText, parameters), """<p class="no-section">This is my clause. My contractor name. And I am born in January 13th 1983</p>""")
   }
 
   it should "be able to extract the variable definitions" in {
 
-    val clauseText =
-      "This is my clause. [[contractor \"the contractor who is going to do the job\"]]. And I am born in [[contractorBirthdate:Date \"The birthdate of the contractor\"]]"
+    val clauseText = "This is my clause. [[contractor \"the contractor who is going to do the job\"]]. And I am born in [[contractorBirthdate:Date \"The birthdate of the contractor\"]]"
 
     compiledAgreement(clauseText) match {
       case Right(compiledVersion) =>
         val variables = compiledVersion.block.variables()
-        variables.head shouldBe VariableDefinition(
-          VariableName("contractor"),
-          None,
-          Some("the contractor who is going to do the job"),
-          None
-        )
-        variables(1) shouldBe VariableDefinition(
-          VariableName("contractorBirthdate"),
-          Some(VariableTypeDefinition(DateType.name)),
-          Some("The birthdate of the contractor"),
-          None
-        )
+        variables.head shouldBe VariableDefinition(VariableName("contractor"), None, Some("the contractor who is going to do the job"), None)
+        variables(1) shouldBe VariableDefinition(VariableName("contractorBirthdate"), Some(VariableTypeDefinition(DateType.name)), Some("The birthdate of the contractor"), None)
       case Left(ex) => fail(ex)
     }
   }
 
   it should "handle conditional blocks" in {
 
-    val clauseText =
-      "This is my clause. [[contractor:Text \"the contractor who is going to do the job\"]]. {{shouldShowBirthdate \"Should we show the birthdate?\" => And I am born in [[contractorBirthdate \"The birthdate of the contractor\" ]]}}"
+    val clauseText = "This is my clause. [[contractor:Text \"the contractor who is going to do the job\"]]. {{shouldShowBirthdate \"Should we show the birthdate?\" => And I am born in [[contractorBirthdate \"The birthdate of the contractor\" ]]}}"
 
-    resultShouldBe(
-      forReview(
-        clauseText,
-        Map(
-          "contractor" -> "David Roon",
-          "shouldShowBirthdate" -> "true",
-          "contractorBirthdate" -> "01.13.1983"
-        )
-      ),
-      """<p class="no-section">This is my clause. David Roon. And I am born in 01.13.1983</p>"""
-    )
+    resultShouldBe(forReview(clauseText, Map(
+      "contractor" -> "David Roon",
+      "shouldShowBirthdate" -> "true",
+      "contractorBirthdate" -> "01.13.1983"
+    )) , """<p class="no-section">This is my clause. David Roon. And I am born in 01.13.1983</p>""")
 
-    resultShouldBe(
-      forReview(
-        clauseText,
-        Map("contractor" -> "David Roon", "shouldShowBirthdate" -> "false")
-      ),
-      """<p class="no-section">This is my clause. David Roon. </p>"""
-    )
+    resultShouldBe(forReview(clauseText, Map(
+      "contractor" -> "David Roon",
+      "shouldShowBirthdate" -> "false"
+    )), """<p class="no-section">This is my clause. David Roon. </p>""")
   }
 
   it should "handle conditional blocks with else" in {
 
-    val clauseText =
-      """This is my clause. [[contractor:Text "the contractor who is going to do the job"]]. {{shouldShowBirthdate "Should we show the birthdate?" => And I am born in [[contractorBirthdate "The birthdate of the contractor"]] :: I am not showing any birthday-related information }}"""
+    val clauseText = """This is my clause. [[contractor:Text "the contractor who is going to do the job"]]. {{shouldShowBirthdate "Should we show the birthdate?" => And I am born in [[contractorBirthdate "The birthdate of the contractor"]] :: I am not showing any birthday-related information }}"""
 
-    resultShouldBe(
-      forReview(
-        clauseText,
-        Map(
-          "contractor" -> "David Roon",
-          "shouldShowBirthdate" -> "true",
-          "contractorBirthdate" -> "01.13.1983"
-        )
-      ),
-      """<p class="no-section">This is my clause. David Roon. And I am born in 01.13.1983 </p>"""
-    )
+    resultShouldBe(forReview(clauseText, Map(
+      "contractor" -> "David Roon",
+      "shouldShowBirthdate" -> "true",
+      "contractorBirthdate" -> "01.13.1983"
+    )) , """<p class="no-section">This is my clause. David Roon. And I am born in 01.13.1983 </p>""")
 
-    resultShouldBe(
-      forReview(
-        clauseText,
-        Map("contractor" -> "David Roon", "shouldShowBirthdate" -> "false")
-      ),
-      """<p class="no-section">This is my clause. David Roon. I am not showing any birthday-related information </p>"""
-    )
+    resultShouldBe(forReview(clauseText, Map(
+      "contractor" -> "David Roon",
+      "shouldShowBirthdate" -> "false"
+    )), """<p class="no-section">This is my clause. David Roon. I am not showing any birthday-related information </p>""")
   }
 
   it should "do post processing for lists" in {
@@ -394,17 +293,11 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
     resultShouldBe(forPreview(text), text3)
   }
 
-  it should "handle link variables with absolute URLs" in {
+   it should "handle link variables with absolute URLs" in {
     val text = """[[link1:Link(label:'homepage';url:'https://openlaw.io')]]"""
 
-    resultShouldBe(
-      forPreview(text),
-      "<div class=\"openlaw-paragraph paragraph-1\"><p class=\"no-section\"><span class=\"markdown-variable markdown-variable-link1\"><a href=\"https://openlaw.io\">homepage</a></span></p></div>"
-    )
-    resultShouldBe(
-      forReview(text),
-      "<p class=\"no-section\"><a href=\"https://openlaw.io\">homepage</a></p>"
-    )
+    resultShouldBe(forPreview(text), "<div class=\"openlaw-paragraph paragraph-1\"><p class=\"no-section\"><span class=\"markdown-variable markdown-variable-link1\"><a href=\"https://openlaw.io\">homepage</a></span></p></div>")
+    resultShouldBe(forReview(text), "<p class=\"no-section\"><a href=\"https://openlaw.io\">homepage</a></p>")
 
   }
 
@@ -415,22 +308,11 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
       case Success(executionResult) =>
         executionResult.getVariables(LinkType).size shouldBe 1
 
-        val link = executionResult
-          .getVariableValues[LinkInfo](LinkType)
-          .right
-          .value
-          .head
-          .underlying
-        link should be(LinkInfo("Log In", "/login"))
+        val link = executionResult.getVariableValues[LinkInfo](LinkType).right.value.head.underlying
+        link should be (LinkInfo("Log In", "/login"))
 
-        resultShouldBe(
-          forPreview(text),
-          "<div class=\"openlaw-paragraph paragraph-1\"><p class=\"no-section\"><span class=\"markdown-variable markdown-variable-link1\"><a href=\"/login\">Log In</a></span></p></div>"
-        )
-        resultShouldBe(
-          forReview(text),
-          "<p class=\"no-section\"><a href=\"/login\">Log In</a></p>"
-        )
+        resultShouldBe(forPreview(text), "<div class=\"openlaw-paragraph paragraph-1\"><p class=\"no-section\"><span class=\"markdown-variable markdown-variable-link1\"><a href=\"/login\">Log In</a></span></p></div>")
+        resultShouldBe(forReview(text), "<p class=\"no-section\"><a href=\"/login\">Log In</a></p>")
       case Left(ex) => fail(ex)
     }
   }
@@ -458,29 +340,17 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
   }
 
   it should "handle image variables with URLs" in {
-    val text =
-      """[[Image1:Image("https://openlaw.io/static/img/pizza-dog-optimized.svg")]]"""
+    val text = """[[Image1:Image("https://openlaw.io/static/img/pizza-dog-optimized.svg")]]"""
 
     executeTemplate(text) match {
       case Right(executionResult) =>
         executionResult.getVariables(ImageType).size shouldBe 1
 
-        val image = executionResult
-          .getVariableValues[OpenlawString](ImageType)
-          .right
-          .value
-          .head
-          .underlying
-        image should be("https://openlaw.io/static/img/pizza-dog-optimized.svg")
+        val image = executionResult.getVariableValues[OpenlawString](ImageType).right.value.head.underlying
+        image should be ("https://openlaw.io/static/img/pizza-dog-optimized.svg")
 
-        resultShouldBe(
-          forPreview(text),
-          "<div class=\"openlaw-paragraph paragraph-1\"><p class=\"no-section\"><span class=\"markdown-variable markdown-variable-Image1\"><img class=\"markdown-embedded-image\" src=\"https://openlaw.io/static/img/pizza-dog-optimized.svg\" /></span></p></div>"
-        )
-        resultShouldBe(
-          forReview(text),
-          "<p class=\"no-section\"><img class=\"markdown-embedded-image\" src=\"https://openlaw.io/static/img/pizza-dog-optimized.svg\" /></p>"
-        )
+        resultShouldBe(forPreview(text), "<div class=\"openlaw-paragraph paragraph-1\"><p class=\"no-section\"><span class=\"markdown-variable markdown-variable-Image1\"><img class=\"markdown-embedded-image\" src=\"https://openlaw.io/static/img/pizza-dog-optimized.svg\" /></span></p></div>")
+        resultShouldBe(forReview(text), "<p class=\"no-section\"><img class=\"markdown-embedded-image\" src=\"https://openlaw.io/static/img/pizza-dog-optimized.svg\" /></p>")
       case Left(ex) => fail(ex)
     }
   }
@@ -505,108 +375,56 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
         val allActions = executionResult.allActions.right.value
         allActions.size shouldBe 1
 
-        val call = executionResult
-          .getVariableValues[EthereumSmartContractCall](EthereumCallType)
-          .right
-          .value
-          .head
-        call.address.evaluate(emptyExecutionResult) shouldBe Right(
-          Some(OpenlawString("0xde0B295669a9FD93d5F28D9Ec85E40f4cb697BAe"))
-        )
-        call.arguments.map(_.toString) shouldBe List("Var1", "Var2", "Var3")
-        call.abi.evaluate(emptyExecutionResult) shouldBe Right(
-          Some(OpenlawString("ipfs:5ihruiherg34893zf"))
-        )
+        val call = executionResult.getVariableValues[EthereumSmartContractCall](EthereumCallType).right.value.head
+        call.address.evaluate(emptyExecutionResult) shouldBe Right(Some(OpenlawString("0xde0B295669a9FD93d5F28D9Ec85E40f4cb697BAe")))
+        call.arguments.map(_.toString) shouldBe List("Var1","Var2","Var3")
+        call.abi.evaluate(emptyExecutionResult) shouldBe Right(Some(OpenlawString("ipfs:5ihruiherg34893zf")))
       case Left(ex) => fail(ex)
     }
   }
 
   it should "be able to have pipe characters" in {
     val text = "This is a | test."
-    resultShouldBe(
-      forReview(text, Map("Var" -> "hello world")),
-      """<p class="no-section">This is a | test.</p>"""
-    )
+    resultShouldBe(forReview(text, Map("Var" -> "hello world")), """<p class="no-section">This is a | test.</p>""")
   }
 
   it should "handle pipe characters even when conditionals are present" in {
     val text = "{{test \"Ttioje\" => ||a little test||}}"
-    resultShouldBe(
-      forReview(text, Map("test" -> "true")),
-      """<p class="no-section">||a little test||</p>"""
-    )
+    resultShouldBe(forReview(text, Map(
+      "test" -> "true",
+    )), """<p class="no-section">||a little test||</p>""")
 
-    resultShouldBe(forReview(text, Map("test" -> "false")), "")
+    resultShouldBe(forReview(text, Map(
+      "test" -> "false"
+    )), "")
   }
 
   it should "be able to emphasize variables" in {
     val text = "* [[Var]] * ** [[Var]] ** *** [[Var]] ***"
-    resultShouldBe(
-      forReview(text, Map("Var" -> "hello world")),
-      """<p class="no-section"><em> hello world </em> <strong> hello world </strong> <strong><em> hello world </em></strong></p>"""
-    )
+    resultShouldBe(forReview(text, Map("Var" -> "hello world")), """<p class="no-section"><em> hello world </em> <strong> hello world </strong> <strong><em> hello world </em></strong></p>""")
   }
 
   it should "be able to underline variables" in {
     val text = "__[[Var]]__"
-    resultShouldBe(
-      forReview(text, Map("Var" -> "hello world")),
-      """<p class="no-section"><u>hello world</u></p>"""
-    )
+    resultShouldBe(forReview(text, Map("Var" -> "hello world")), """<p class="no-section"><u>hello world</u></p>""")
   }
 
   it should "be able to override section symbols" in {
-    resultShouldBe(
-      forReview("^ Section 1", Map()),
-      """<ul class="list-lvl-1"><li><p>1.  Section 1</p></li></ul>"""
-    )
-    resultShouldBe(
-      forReview("^(_(symbol: 'Decimal')) Section 1", Map()),
-      """<ul class="list-lvl-1"><li><p>1.  Section 1</p></li></ul>"""
-    )
-    resultShouldBe(
-      forReview("^(_(symbol: 'Fake')) Section 1", Map()),
-      """<ul class="list-lvl-1"><li><p>1.  Section 1</p></li></ul>"""
-    )
-    resultShouldBe(
-      forReview("^(_(symbol: 'LowerLetter')) Section 1", Map()),
-      """<ul class="list-lvl-1"><li><p>a.  Section 1</p></li></ul>"""
-    )
-    resultShouldBe(
-      forReview("^(_(symbol: 'UpperLetter')) Section 1", Map()),
-      """<ul class="list-lvl-1"><li><p>A.  Section 1</p></li></ul>"""
-    )
-    resultShouldBe(
-      forReview("^(_(symbol: 'LowerRoman')) Section 1", Map()),
-      """<ul class="list-lvl-1"><li><p>i.  Section 1</p></li></ul>"""
-    )
-    resultShouldBe(
-      forReview("^(_(symbol: 'UpperRoman')) Section 1", Map()),
-      """<ul class="list-lvl-1"><li><p>I.  Section 1</p></li></ul>"""
-    )
-    resultShouldBe(
-      forReview("^(_(symbol: 'Hide')) Section 1", Map()),
-      """<ul class="list-lvl-1"><li><p>  Section 1</p></li></ul>"""
-    )
+    resultShouldBe(forReview("^ Section 1", Map()), """<ul class="list-lvl-1"><li><p>1.  Section 1</p></li></ul>""")
+    resultShouldBe(forReview("^(_(symbol: 'Decimal')) Section 1", Map()), """<ul class="list-lvl-1"><li><p>1.  Section 1</p></li></ul>""")
+    resultShouldBe(forReview("^(_(symbol: 'Fake')) Section 1", Map()), """<ul class="list-lvl-1"><li><p>1.  Section 1</p></li></ul>""")
+    resultShouldBe(forReview("^(_(symbol: 'LowerLetter')) Section 1", Map()), """<ul class="list-lvl-1"><li><p>a.  Section 1</p></li></ul>""")
+    resultShouldBe(forReview("^(_(symbol: 'UpperLetter')) Section 1", Map()), """<ul class="list-lvl-1"><li><p>A.  Section 1</p></li></ul>""")
+    resultShouldBe(forReview("^(_(symbol: 'LowerRoman')) Section 1", Map()), """<ul class="list-lvl-1"><li><p>i.  Section 1</p></li></ul>""")
+    resultShouldBe(forReview("^(_(symbol: 'UpperRoman')) Section 1", Map()), """<ul class="list-lvl-1"><li><p>I.  Section 1</p></li></ul>""")
+    resultShouldBe(forReview("^(_(symbol: 'Hide')) Section 1", Map()), """<ul class="list-lvl-1"><li><p>  Section 1</p></li></ul>""")
   }
 
   it should "be able to override section formats" in {
-    resultShouldBe(
-      forReview("^ Section 1", Map()),
-      """<ul class="list-lvl-1"><li><p>1.  Section 1</p></li></ul>"""
-    )
-    resultShouldBe(
-      forReview("^(_(format: 'Period')) Section 1", Map()),
-      """<ul class="list-lvl-1"><li><p>1.  Section 1</p></li></ul>"""
-    )
-    resultShouldBe(
-      forReview("^(_(format: 'Parens')) Section 1", Map()),
-      """<ul class="list-lvl-1"><li><p>(1)  Section 1</p></li></ul>"""
-    )
-    resultShouldBe(
-      forReview("^(_(format: 'RightParen')) Section 1", Map()),
-      """<ul class="list-lvl-1"><li><p>1)  Section 1</p></li></ul>"""
-    )
+    resultShouldBe(forReview("^ Section 1", Map()), """<ul class="list-lvl-1"><li><p>1.  Section 1</p></li></ul>""")
+    resultShouldBe(forReview("^(_(format: 'Period')) Section 1", Map()), """<ul class="list-lvl-1"><li><p>1.  Section 1</p></li></ul>""")
+    resultShouldBe(forReview("^(_(format: 'Parens')) Section 1", Map()), """<ul class="list-lvl-1"><li><p>(1)  Section 1</p></li></ul>""")
+    resultShouldBe(forReview("^(_(format: 'RightParen')) Section 1", Map()), """<ul class="list-lvl-1"><li><p>1)  Section 1</p></li></ul>""")
   }
 
   it should "be able to reference sections" in {
@@ -617,10 +435,7 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
         |
         |[[s1ai]]
       """.stripMargin
-    resultShouldBe(
-      forReview(text, Map()),
-      """<ul class="list-lvl-1"><li><p>1.  Section 1<br /></p><ul class="list-lvl-2"><li><p>(a)  Section 1.a<br /></p><ul class="list-lvl-3"><li><p>(i)  Section 1.a.i</p><p>1.a.i<br />      </p></li></ul></li></ul></li></ul>"""
-    )
+    resultShouldBe(forReview(text, Map()), """<ul class="list-lvl-1"><li><p>1.  Section 1<br /></p><ul class="list-lvl-2"><li><p>(a)  Section 1.a<br /></p><ul class="list-lvl-3"><li><p>(i)  Section 1.a.i</p><p>1.a.i<br />      </p></li></ul></li></ul></li></ul>""")
   }
 
   it should "be able to reference sections with custom symbols and formats" in {
@@ -631,199 +446,92 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
         |
         |[[s1ai]]
       """.stripMargin
-    resultShouldBe(
-      forReview(text, Map()),
-      """<ul class="list-lvl-1"><li><p>1.  Section 1<br /></p><ul class="list-lvl-2"><li><p>(a)  Section 1.a<br /></p><ul class="list-lvl-3"><li><p>1.  Section 1.a.i</p><p>1.a.1<br />      </p></li></ul></li></ul></li></ul>"""
-    )
+    resultShouldBe(forReview(text, Map()), """<ul class="list-lvl-1"><li><p>1.  Section 1<br /></p><ul class="list-lvl-2"><li><p>(a)  Section 1.a<br /></p><ul class="list-lvl-3"><li><p>1.  Section 1.a.i</p><p>1.a.1<br />      </p></li></ul></li></ul></li></ul>""")
   }
 
   it should "be able to override section symbols and formats" in {
-    resultShouldBe(
-      forReview("^ Section 1", Map()),
-      """<ul class="list-lvl-1"><li><p>1.  Section 1</p></li></ul>"""
-    )
-    resultShouldBe(
-      forReview(
-        "^(_(symbol: 'UpperRoman'; format: 'Period')) Section 1",
-        Map()
-      ),
-      """<ul class="list-lvl-1"><li><p>I.  Section 1</p></li></ul>"""
-    )
-    resultShouldBe(
-      forReview(
-        "^(_(symbol: 'LowerLetter'; format: 'Parens')) Section 1",
-        Map()
-      ),
-      """<ul class="list-lvl-1"><li><p>(a)  Section 1</p></li></ul>"""
-    )
-    resultShouldBe(
-      forReview(
-        "^(_(symbol: 'UpperLetter'; format: 'RightParen')) Section 1",
-        Map()
-      ),
-      """<ul class="list-lvl-1"><li><p>A)  Section 1</p></li></ul>"""
-    )
-    resultShouldBe(
-      forReview("^(_(symbol: 'Hide'; format: 'RightParen')) Section 1", Map()),
-      """<ul class="list-lvl-1"><li><p>  Section 1</p></li></ul>"""
-    )
+    resultShouldBe(forReview("^ Section 1", Map()), """<ul class="list-lvl-1"><li><p>1.  Section 1</p></li></ul>""")
+    resultShouldBe(forReview("^(_(symbol: 'UpperRoman'; format: 'Period')) Section 1", Map()), """<ul class="list-lvl-1"><li><p>I.  Section 1</p></li></ul>""")
+    resultShouldBe(forReview("^(_(symbol: 'LowerLetter'; format: 'Parens')) Section 1", Map()), """<ul class="list-lvl-1"><li><p>(a)  Section 1</p></li></ul>""")
+    resultShouldBe(forReview("^(_(symbol: 'UpperLetter'; format: 'RightParen')) Section 1", Map()), """<ul class="list-lvl-1"><li><p>A)  Section 1</p></li></ul>""")
+    resultShouldBe(forReview("^(_(symbol: 'Hide'; format: 'RightParen')) Section 1", Map()), """<ul class="list-lvl-1"><li><p>  Section 1</p></li></ul>""")
   }
 
   it should "be able to override subsequent section symbols and formats" in {
-    resultShouldBe(
-      forReview("^ Section 1^ Section 2", Map()),
-      """<ul class="list-lvl-1"><li><p>1.  Section 1</p></li><li><p>2.  Section 2</p></li></ul>"""
-    )
-    resultShouldBe(
-      forReview(
-        "^(_(symbol: 'LowerLetter'; format: 'Parens')) Section 1^ Section 2",
-        Map()
-      ),
-      """<ul class="list-lvl-1"><li><p>(a)  Section 1</p></li><li><p>(b)  Section 2</p></li></ul>"""
-    )
-    resultShouldBe(
-      forReview(
-        "^(_(symbol: 'LowerLetter')) Section 1^ Section 2^(_(format: 'Parens')) Section 3^ Section 4",
-        Map()
-      ),
-      """<ul class="list-lvl-1"><li><p>a.  Section 1</p></li><li><p>b.  Section 2</p></li><li><p>(c)  Section 3</p></li><li><p>(d)  Section 4</p></li></ul>"""
-    )
+    resultShouldBe(forReview("^ Section 1^ Section 2", Map()), """<ul class="list-lvl-1"><li><p>1.  Section 1</p></li><li><p>2.  Section 2</p></li></ul>""")
+    resultShouldBe(forReview("^(_(symbol: 'LowerLetter'; format: 'Parens')) Section 1^ Section 2", Map()), """<ul class="list-lvl-1"><li><p>(a)  Section 1</p></li><li><p>(b)  Section 2</p></li></ul>""")
+    resultShouldBe(forReview("^(_(symbol: 'LowerLetter')) Section 1^ Section 2^(_(format: 'Parens')) Section 3^ Section 4", Map()), """<ul class="list-lvl-1"><li><p>a.  Section 1</p></li><li><p>b.  Section 2</p></li><li><p>(c)  Section 3</p></li><li><p>(d)  Section 4</p></li></ul>""")
   }
 
   it should "not be able to emphasize sections" in {
-    resultShouldBe(
-      forReview("* ^ Section 1 *", Map()),
-      """<p class="no-section">* </p><ul class="list-lvl-1"><li><p>1.  Section 1 *</p></li></ul>"""
-    )
-    resultShouldBe(
-      forReview("** ^ Section 1 **", Map()),
-      """<p class="no-section">** </p><ul class="list-lvl-1"><li><p>1.  Section 1 **</p></li></ul>"""
-    )
-    resultShouldBe(
-      forReview("*** ^ Section 1 ***", Map()),
-      """<p class="no-section">*** </p><ul class="list-lvl-1"><li><p>1.  Section 1 ***</p></li></ul>"""
-    )
+    resultShouldBe(forReview("* ^ Section 1 *", Map()), """<p class="no-section">* </p><ul class="list-lvl-1"><li><p>1.  Section 1 *</p></li></ul>""")
+    resultShouldBe(forReview("** ^ Section 1 **", Map()), """<p class="no-section">** </p><ul class="list-lvl-1"><li><p>1.  Section 1 **</p></li></ul>""")
+    resultShouldBe(forReview("*** ^ Section 1 ***", Map()), """<p class="no-section">*** </p><ul class="list-lvl-1"><li><p>1.  Section 1 ***</p></li></ul>""")
   }
 
   it should "not be able to emphasize conditionals" in {
-    resultShouldBe(
-      forReview(
-        "* <%[[var1:Number]]%>{{var1 > 0 => test}} *",
-        Map("var1" -> "1")
-      ),
-      """<p class="no-section">* test *</p>"""
-    )
-    resultShouldBe(
-      forReview(
-        "** <%[[var1:Number]]%>{{var1 > 0 => test}} **",
-        Map("var1" -> "1")
-      ),
-      """<p class="no-section">** test **</p>"""
-    )
-    resultShouldBe(
-      forReview(
-        "*** <%[[var1:Number]]%>{{var1 > 0 => test}} ***",
-        Map("var1" -> "1")
-      ),
-      """<p class="no-section">*** test ***</p>"""
-    )
+    resultShouldBe(forReview("* <%[[var1:Number]]%>{{var1 > 0 => test}} *", Map("var1" -> "1")), """<p class="no-section">* test *</p>""")
+    resultShouldBe(forReview("** <%[[var1:Number]]%>{{var1 > 0 => test}} **", Map("var1" -> "1")), """<p class="no-section">** test **</p>""")
+    resultShouldBe(forReview("*** <%[[var1:Number]]%>{{var1 > 0 => test}} ***", Map("var1" -> "1")), """<p class="no-section">*** test ***</p>""")
   }
 
   it should "not be able to emphasize across newlines" in {
-    resultShouldBe(
-      forReview("* This is \n text. *", Map()),
-      """<p class="no-section">* This is <br /> text. *</p>"""
-    )
-    resultShouldBe(
-      forReview("** This is \n text. **", Map()),
-      """<p class="no-section">** This is <br /> text. **</p>"""
-    )
-    resultShouldBe(
-      forReview("*** This is \n text. ***", Map()),
-      """<p class="no-section">*** This is <br /> text. ***</p>"""
-    )
+    resultShouldBe(forReview("* This is \n text. *", Map()), """<p class="no-section">* This is <br /> text. *</p>""")
+    resultShouldBe(forReview("** This is \n text. **", Map()), """<p class="no-section">** This is <br /> text. **</p>""")
+    resultShouldBe(forReview("*** This is \n text. ***", Map()), """<p class="no-section">*** This is <br /> text. ***</p>""")
   }
 
   it should "parse unterminated emphasis as a normal star character" in {
     val text = "lorem * ipsum"
-    resultShouldBe(
-      forReview(text),
-      """<p class="no-section">lorem * ipsum</p>"""
-    )
+    resultShouldBe(forReview(text), """<p class="no-section">lorem * ipsum</p>""")
   }
 
   it should "parse eth address and render them properly" in {
     val text = "[[my address:EthAddress]]"
-    resultShouldBe(
-      forReview(
-        text,
-        Map("my address" -> "0x30c6738E9A5CC946D6ae1f176Dc69Fa1663b3b2C")
-      ),
-      """<p class="no-section">30c6738e9a5cc946d6ae1f176dc69fa1663b3b2c</p>"""
-    )
+    resultShouldBe(forReview(text, Map("my address" -> "0x30c6738E9A5CC946D6ae1f176Dc69Fa1663b3b2C")), """<p class="no-section">30c6738e9a5cc946d6ae1f176dc69fa1663b3b2c</p>""")
   }
 
   it should "accept expressions for conditional blocks greater than" in {
     val text =
       """<%[[var1:Number]][[var2:Number]]%>{{var1 > var2 => iojiwofjiowejf iwjfiowejfiowejfiowejfiowefj}}""".stripMargin
-    resultShouldBe(
-      forReview(text, Map("var1" -> "112", "var2" -> "16")),
-      """<p class="no-section">iojiwofjiowejf iwjfiowejfiowejfiowejfiowefj</p>"""
-    )
+    resultShouldBe(forReview(text, Map("var1" -> "112", "var2" -> "16")), """<p class="no-section">iojiwofjiowejf iwjfiowejfiowejfiowejfiowefj</p>""")
   }
 
   it should "accept expressions for conditional blocks greater or equal" in {
     val text =
       """<%[[var1:Number]][[var2:Number]]%>{{var1 >= var2 => iojiwofjiowejf iwjfiowejfiowejfiowejfiowefj}}""".stripMargin
-    resultShouldBe(
-      forReview(text, Map("var1" -> "112", "var2" -> "16")),
-      """<p class="no-section">iojiwofjiowejf iwjfiowejfiowejfiowejfiowefj</p>"""
-    )
-    resultShouldBe(
-      forReview(text, Map("var1" -> "16", "var2" -> "16")),
-      """<p class="no-section">iojiwofjiowejf iwjfiowejfiowejfiowejfiowefj</p>"""
-    )
+    resultShouldBe(forReview(text, Map("var1" -> "112", "var2" -> "16")), """<p class="no-section">iojiwofjiowejf iwjfiowejfiowejfiowejfiowefj</p>""")
+    resultShouldBe(forReview(text, Map("var1" -> "16", "var2" -> "16")), """<p class="no-section">iojiwofjiowejf iwjfiowejfiowejfiowejfiowefj</p>""")
     resultShouldBe(forReview(text, Map("var1" -> "15", "var2" -> "16")), "")
   }
 
   it should "accept expressions with just a variable" in {
     val text =
       """{{var1 "this is a variable" => iojiwofjiowejf iwjfiowejfiowejfiowejfiowefj}}""".stripMargin
-    resultShouldBe(
-      forReview(text, Map("var1" -> "true")),
-      """<p class="no-section">iojiwofjiowejf iwjfiowejfiowejfiowejfiowefj</p>"""
-    )
+    resultShouldBe(forReview(text, Map("var1" -> "true")), """<p class="no-section">iojiwofjiowejf iwjfiowejfiowejfiowejfiowefj</p>""")
   }
 
   it should "accept expressions for conditional blocks lesser than" in {
     val text =
       """[[#var1:Number]][[#var2:Number]]{{var1 < var2 => iojiwofjiowejf iwjfiowejfiowejfiowejfiowefj}}""".stripMargin
 
-    resultShouldBe(
-      forReview(text, Map("var1" -> "12", "var2" -> "16")),
-      """<p class="no-section">iojiwofjiowejf iwjfiowejfiowejfiowejfiowefj</p>"""
-    )
+    resultShouldBe(forReview(text, Map("var1" -> "12", "var2" -> "16")), """<p class="no-section">iojiwofjiowejf iwjfiowejfiowejfiowejfiowefj</p>""")
   }
 
   it should "accept nested expressions for conditional" in {
     val text =
       """<%[[var1:Number]] [[var2:Number]]%>{{(var1 < var2) && (var1 < var2) => iojiwofjiowejf iwjfiowejfiowejfiowejfiowefj}}""".stripMargin
 
-    resultShouldBe(
-      forReview(text, Map("var1" -> "12", "var2" -> "116")),
-      """<p class="no-section">iojiwofjiowejf iwjfiowejfiowejfiowejfiowefj</p>"""
-    )
+    resultShouldBe(forReview(text, Map("var1" -> "12", "var2" -> "116")), """<p class="no-section">iojiwofjiowejf iwjfiowejfiowejfiowejfiowefj</p>""")
   }
 
   it should "be able to define a default value" in {
-    val clauseText =
-      "This is my clause. [[contractor:Text(\"Hello my friend\")]]"
+    val clauseText = "This is my clause. [[contractor:Text(\"Hello my friend\")]]"
 
     executeTemplate(clauseText) match {
       case Success(r) =>
         r.getVariable("contractor").flatMap(_.defaultValue) match {
-          case Some(OneValueParameter(StringConstant(str, _))) =>
-            str shouldBe "Hello my friend"
+          case Some(OneValueParameter(StringConstant(str,_))) => str shouldBe "Hello my friend"
           case result => fail(result.toString)
         }
       case Failure(ex, message) =>
@@ -832,29 +540,22 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
   }
 
   it should "be able to define multiple default values" in {
-    val clauseText =
-      "This is my clause. [[contractor:Choice(\"First option\", \"Second option\")]]"
+    val clauseText = "This is my clause. [[contractor:Choice(\"First option\", \"Second option\")]]"
 
-    executeTemplate(clauseText).toOption
-      .flatMap(_.getVariable("contractor").flatMap(_.defaultValue)) match {
+    executeTemplate(clauseText).toOption.flatMap(_.getVariable("contractor").flatMap(_.defaultValue)) match {
       case Some(ListParameter(vector)) =>
-        val list = vector.map(_.evaluate(emptyExecutionResult))
-        list.map({ case Success(Some(value)) => value }) shouldBe List(
-          "First option",
-          "Second option"
-        )
+				val list = vector.map(_.evaluate(emptyExecutionResult))
+				list.map({case Success(Some(value)) => value}) shouldBe List("First option", "Second option")
       case result =>
-        fail(result.toString)
+				fail(result.toString)
     }
   }
 
   it should "not be able to define a default value for a number that is not a number" in {
-    val clauseText =
-      "This is my clause. [[contractor:Number(\"Hello my friend\")]]"
+    val clauseText = "This is my clause. [[contractor:Number(\"Hello my friend\")]]"
 
     structureAgreement(clauseText) match {
-      case Left(ex) =>
-        ex.message shouldBe "the constructor type should be Number but is Text"
+      case Left(ex) => ex.message shouldBe "the constructor type should be Number but is Text"
       case Right(_) => fail("should fail")
     }
   }
@@ -863,17 +564,13 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
     val clauseText = "This is my clause. [[contractor:Number(24)]]"
 
     executeTemplate(clauseText) match {
-      case Right(executionResult) =>
-        executionResult.getVariable("contractor") match {
-          case Some(variable) =>
-            variable.defaultValue match {
-              case Some(OneValueParameter(NumberConstant(n, _))) =>
-                n shouldBe BigDecimal("24")
-              case something =>
-                fail("default value is not correct:" + something)
-            }
-          case None => fail("variable not found")
+      case Right(executionResult) => executionResult.getVariable("contractor") match {
+        case Some(variable) => variable.defaultValue match {
+          case Some(OneValueParameter(NumberConstant(n,_))) => n shouldBe BigDecimal("24")
+          case something => fail("default value is not correct:" + something)
         }
+        case None => fail("variable not found")
+      }
       case Left(ex) => fail(ex)
     }
   }
@@ -881,34 +578,25 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
   it should "be able to define a default value for a date by parsing the date" in {
     val clauseText = "This is my clause. [[contractor:Date(\"2017-06-24\")]]"
     executeTemplate(clauseText) match {
-      case Right(executionResult) =>
-        executionResult.getVariable("contractor") match {
-          case Some(variable) =>
-            variable.defaultValue match {
-              case Some(OneValueParameter(StringConstant(text, _))) =>
-                text shouldBe "2017-06-24"
-              case something =>
-                fail("default value is not correct:" + something)
-            }
-          case None => fail("contractor variable not found")
+      case Right(executionResult) => executionResult.getVariable("contractor") match {
+        case Some(variable) => variable.defaultValue match {
+          case Some(OneValueParameter(StringConstant(text,_))) => text shouldBe "2017-06-24"
+          case something => fail("default value is not correct:" + something)
         }
+        case None => fail("contractor variable not found")
+      }
       case Left(ex) => fail(ex)
     }
   }
 
   it should "be able to define a default value for a date time by parsing the date" in {
-    val clauseText =
-      "This is my clause. [[contractor:DateTime(\"2017-06-24 13:45:00\")]]"
+    val clauseText = "This is my clause. [[contractor:DateTime(\"2017-06-24 13:45:00\")]]"
 
     executeTemplate(clauseText) match {
-      case Right(executionResult) =>
-        executionResult
-          .getVariable("contractor")
-          .flatMap(_.defaultValue) match {
-          case Some(OneValueParameter(StringConstant(text, _))) =>
-            text shouldBe "2017-06-24 13:45:00"
-          case something => fail("default value is not correct:" + something)
-        }
+      case Right(executionResult) => executionResult.getVariable("contractor").flatMap(_.defaultValue) match {
+        case Some(OneValueParameter(StringConstant(text,_))) => text shouldBe "2017-06-24 13:45:00"
+        case something => fail("default value is not correct:" + something)
+      }
       case Left(ex) =>
         ex.e.printStackTrace()
         fail(ex)
@@ -919,69 +607,47 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
     val text =
       """<%[[var1:YesNo]][[var2:YesNo]]%>{{var1 && var2 => iojiwofjiowejf iwjfiowejfiowejfiowejfiowefj}}""".stripMargin
 
-    resultShouldBe(
-      forReview(text, Map("var1" -> "true", "var2" -> "true")),
-      """<p class="no-section">iojiwofjiowejf iwjfiowejfiowejfiowejfiowefj</p>"""
-    )
+    resultShouldBe(forReview(text, Map("var1" -> "true", "var2" -> "true")), """<p class="no-section">iojiwofjiowejf iwjfiowejfiowejfiowejfiowefj</p>""")
   }
 
   it should "be able to use constants in comparaison expressions" in {
     val text =
       """[[#var1:Number]]{{var1 > 10 => iojiwofjiowejf iwjfiowejfiowejfiowejfiowefj}}""".stripMargin
 
-    resultShouldBe(
-      forReview(text, Map("var1" -> "12")),
-      """<p class="no-section">iojiwofjiowejf iwjfiowejfiowejfiowejfiowefj</p>"""
-    )
+    resultShouldBe(forReview(text, Map("var1" -> "12")), """<p class="no-section">iojiwofjiowejf iwjfiowejfiowejfiowejfiowefj</p>""")
   }
 
   it should "be able to use constants in comparaison expressions with equals too" in {
     val text =
       """[[#var1:Number]]{{var1 = 12 => iojiwofjiowejf iwjfiowejfiowejfiowejfiowefj}}""".stripMargin
 
-    resultShouldBe(
-      forReview(text, Map("var1" -> "12")),
-      """<p class="no-section">iojiwofjiowejf iwjfiowejfiowejfiowejfiowefj</p>"""
-    )
+    resultShouldBe(forReview(text, Map("var1" -> "12")), """<p class="no-section">iojiwofjiowejf iwjfiowejfiowejfiowejfiowefj</p>""")
   }
 
   it should "be able to use constants in equals expressions" in {
     val text =
       """[[#var1:Number]]{{var1 = 10 => iojiwofjiowejf iwjfiowejfiowejfiowejfiowefj}}""".stripMargin
 
-    resultShouldBe(
-      forReview(text, Map("var1" -> "10")),
-      """<p class="no-section">iojiwofjiowejf iwjfiowejfiowejfiowejfiowefj</p>"""
-    )
+    resultShouldBe(forReview(text, Map("var1" -> "10")), """<p class="no-section">iojiwofjiowejf iwjfiowejfiowejfiowejfiowefj</p>""")
   }
   it should "be able to use aliasing " in {
     val text =
       """[[#var2:Number]][[@var1 = var2 + 10]]{{var1 > 10 => iojiwofjiowejf iwjfiowejfiowejfiowejfiowefj}}""".stripMargin
 
-    resultShouldBe(
-      forReview(text, Map("var2" -> "10")),
-      """<p class="no-section">iojiwofjiowejf iwjfiowejfiowejfiowejfiowefj</p>"""
-    )
+    resultShouldBe(forReview(text, Map("var2" -> "10")), """<p class="no-section">iojiwofjiowejf iwjfiowejfiowejfiowejfiowefj</p>""")
   }
 
   it should "be able to use aliasing 2" in {
     val text =
       """[[#var2:Number]][[@var1 = 10 + var2]]{{var1 > 10 => iojiwofjiowejf iwjfiowejfiowejfiowejfiowefj}}""".stripMargin
 
-    resultShouldBe(
-      forReview(text, Map("var2" -> "10")),
-      """<p class="no-section">iojiwofjiowejf iwjfiowejfiowejfiowejfiowefj</p>"""
-    )
+    resultShouldBe(forReview(text, Map("var2" -> "10")), """<p class="no-section">iojiwofjiowejf iwjfiowejfiowejfiowejfiowefj</p>""")
   }
 
   it should "be able to use aliasing 3" in {
-    val text =
-      """[[#var2:Number]][[#var1:Number]][[@var3 = var1 + var2]][[var3]]{{var3 > 39 =>iojiwofjiowejf iwjfiowejfiowejfiowejfiowefj}}""".stripMargin
+    val text = """[[#var2:Number]][[#var1:Number]][[@var3 = var1 + var2]][[var3]]{{var3 > 39 =>iojiwofjiowejf iwjfiowejfiowejfiowejfiowefj}}""".stripMargin
 
-    resultShouldBe(
-      forReview(text, Map("var2" -> "10", "var1" -> "30")),
-      """<p class="no-section">40iojiwofjiowejf iwjfiowejfiowejfiowejfiowefj</p>"""
-    )
+    resultShouldBe(forReview(text, Map("var2" -> "10", "var1" -> "30")), """<p class="no-section">40iojiwofjiowejf iwjfiowejfiowejfiowejfiowefj</p>""")
   }
 
   it should "handle cyclic dependencies" in {
@@ -1027,7 +693,7 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
       case Left(ex) =>
         ex.message shouldEqual "alias expression uses undefined variables b"
       case Right(_) =>
-        fail("this should fail")
+        fail(s"this should fail")
     }
   }
 
@@ -1039,12 +705,12 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
       case Left(ex) =>
         ex.message shouldEqual "error while processing the new variable var2. The variable \"var3\" is used in the constructor but has not been defined"
       case Right(_) =>
-        fail("this should fail")
+        fail(s"this should fail")
     }
   }
 
   it should "handle code blocks" in {
-    val text =
+    val text=
       """<%
         |# this is a comment
         |[[Var1:Number]]
@@ -1058,44 +724,31 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
         |)]]
         |%>[[Var2]]""".stripMargin
 
-    resultShouldBe(
-      forReview(text, Map("Var1" -> "2202")),
-      """<p class="no-section">2,206</p>"""
-    )
+    resultShouldBe(forReview(text, Map("Var1" -> "2202")), """<p class="no-section">2,206</p>""")
   }
 
   it should "handle not logic" in {
-    val text =
-      """<%[[My Var:YesNo]][[Another:YesNo]]%>{{My Var && !Another => iojiowejfiowejfiowejfioewjf }}""".stripMargin
+    val text="""<%[[My Var:YesNo]][[Another:YesNo]]%>{{My Var && !Another => iojiowejfiowejfiowejfioewjf }}""".stripMargin
 
     executeTemplate(text) match {
-      case Right(executionResult) =>
-        executionResult.getVariables.map(_.name.name).toSet shouldBe Set(
-          "My Var",
-          "Another"
-        )
+      case Right(executionResult) => executionResult.getVariables.map(_.name.name).toSet shouldBe Set("My Var", "Another")
       case Left(ex) => fail(ex)
     }
   }
 
   it should "let you put different quote characters in a string" in {
-    val text =
-      """{{My Var "that's it!" => iojiowejfiowejfiowejfioewjf }}""".stripMargin
+    val text="""{{My Var "that's it!" => iojiowejfiowejfiowejfioewjf }}""".stripMargin
 
     executeTemplate(text) match {
       case Right(executionResult) =>
-        executionResult.getVariables.map(_.name.name).toSet shouldBe Set(
-          "My Var"
-        )
-        executionResult.getVariables.map(_.description).head shouldBe Some(
-          "that's it!"
-        )
+        executionResult.getVariables.map(_.name.name).toSet shouldBe Set("My Var")
+        executionResult.getVariables.map(_.description).head shouldBe Some("that's it!")
       case Left(ex) => fail(ex)
     }
   }
 
   it should "throw an error if the variable types used in an alias don't match" in {
-    val text =
+    val text=
       """
         [[Var 1:Number]]
         [[Var 2:Text]]
@@ -1111,113 +764,76 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
   }
 
   it should "let use calculation between periods and dates" in {
-    val text =
+    val text=
       """<%[[Var 1:Period]]
         [[Var 2:DateTime]]
         [[@New Date = Var 1 + Var 2]]%>[[New Date]]""".stripMargin
 
-    resultShouldBe(
-      forReview(
-        text,
-        Map(
-          "Var 1" -> "1 day",
-          "Var 2" -> (LocalDateTime.now
-            .withYear(2018)
-            .withMonth(1)
-            .withDayOfMonth(1)
-            .withHour(10)
-            .withMinute(10)
-            .withSecond(0)
-            .toEpochSecond(ZoneOffset.UTC) * 1000).toString
-        )
-      ),
-      """<p class="no-section">January 2, 2018 10:10:00</p>"""
-    )
+    resultShouldBe(forReview(text,Map("Var 1" -> "1 day","Var 2" -> (LocalDateTime.now
+      .withYear(2018)
+      .withMonth(1)
+      .withDayOfMonth(1)
+      .withHour(10)
+      .withMinute(10)
+      .withSecond(0)
+      .toEpochSecond(ZoneOffset.UTC) * 1000).toString
+    )),"""<p class="no-section">January 2, 2018 10:10:00</p>""")
   }
 
   it should "let use calculation between periods and dates with constants" in {
-    val text =
+    val text=
       """<%[[Var 2:DateTime]]
         [[@New Date = Var 2 + "1 day"]]%>[[New Date]]""".stripMargin
 
-    resultShouldBe(
-      forReview(
-        text,
-        Map(
-          "Var 1" -> "1 day",
-          "Var 2" -> (LocalDateTime.now
-            .withYear(2018)
-            .withMonth(1)
-            .withDayOfMonth(1)
-            .withHour(10)
-            .withMinute(10)
-            .withSecond(0)
-            .toEpochSecond(ZoneOffset.UTC) * 1000).toString
-        )
-      ),
-      """<p class="no-section">January 2, 2018 10:10:00</p>"""
-    )
+    resultShouldBe(forReview(text,Map("Var 1" -> "1 day","Var 2" -> (LocalDateTime.now
+      .withYear(2018)
+      .withMonth(1)
+      .withDayOfMonth(1)
+      .withHour(10)
+      .withMinute(10)
+      .withSecond(0)
+      .toEpochSecond(ZoneOffset.UTC) * 1000).toString
+    )), """<p class="no-section">January 2, 2018 10:10:00</p>""")
   }
 
   it should "format dates with built in formatters" in {
-    resultShouldBe(
-      forReview("""[[date:DateTime("2017-06-24 13:45:00") | year]]""", Map()),
-      """<p class="no-section">2017</p>"""
-    )
-    resultShouldBe(
-      forReview("""[[date:DateTime("2017-06-24 13:45:00") | day]]""", Map()),
-      """<p class="no-section">24</p>"""
-    )
-    resultShouldBe(
-      forReview(
-        """[[date:DateTime("2017-06-24 13:45:00") | day_name]]""",
-        Map()
-      ),
-      """<p class="no-section">Saturday</p>"""
-    )
-    resultShouldBe(
-      forReview("""[[date:DateTime("2017-06-24 13:45:00") | month]]""", Map()),
-      """<p class="no-section">6</p>"""
-    )
-    resultShouldBe(
-      forReview(
-        """[[date:DateTime("2017-06-24 13:45:00") | month_name]]""",
-        Map()
-      ),
-      """<p class="no-section">June</p>"""
-    )
+    resultShouldBe(forReview("""[[date:DateTime("2017-06-24 13:45:00") | year]]""",Map()), """<p class="no-section">2017</p>""")
+    resultShouldBe(forReview("""[[date:DateTime("2017-06-24 13:45:00") | day]]""",Map()), """<p class="no-section">24</p>""")
+    resultShouldBe(forReview("""[[date:DateTime("2017-06-24 13:45:00") | day_name]]""",Map()), """<p class="no-section">Saturday</p>""")
+    resultShouldBe(forReview("""[[date:DateTime("2017-06-24 13:45:00") | month]]""",Map()), """<p class="no-section">6</p>""")
+    resultShouldBe(forReview("""[[date:DateTime("2017-06-24 13:45:00") | month_name]]""",Map()), """<p class="no-section">June</p>""")
   }
 
   it should "handle a set of conditionals " in {
-    val text =
+    val text=
       """{{
         |{{Condition 1 "This is a condition" => Condition 1}}
         |{{Condition 2 "This is another condition" => Condition 2}}
         |}}""".stripMargin
 
-    resultShouldBe(
-      forReview(text, Map("Condition 1" -> "false", "Condition 2" -> "false")),
-      ""
-    )
+    resultShouldBe(forReview(text, Map(
+      "Condition 1" -> "false",
+      "Condition 2" -> "false"
+    )),"")
 
-    resultShouldBe(
-      forReview(text, Map("Condition 1" -> "true", "Condition 2" -> "false")),
-      """<p class="no-section">Condition 1</p>"""
-    )
+    resultShouldBe(forReview(text, Map(
+      "Condition 1" -> "true",
+      "Condition 2" -> "false"
+    )), """<p class="no-section">Condition 1</p>""")
 
-    resultShouldBe(
-      forReview(text, Map("Condition 1" -> "false", "Condition 2" -> "true")),
-      """<p class="no-section">Condition 2</p>"""
-    )
+    resultShouldBe(forReview(text, Map(
+      "Condition 1" -> "false",
+      "Condition 2" -> "true"
+    )), """<p class="no-section">Condition 2</p>""")
 
-    resultShouldBe(
-      forReview(text, Map("Condition 1" -> "true", "Condition 2" -> "true")),
-      """<p class="no-section">Condition 1</p>"""
-    )
+    resultShouldBe(forReview(text, Map(
+      "Condition 1" -> "true",
+      "Condition 2" -> "true"
+    )), """<p class="no-section">Condition 1</p>""")
   }
 
   it should "clean the text if there is too many returns" in {
-    val text =
+    val text=
       """this is a first line
         |
         |this should not be changed
@@ -1228,10 +844,8 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
         |
         |
         |here too""".stripMargin
-    resultShouldBe(
-      forReview(text),
-      """<p class="no-section">this is a first line</p><p class="no-section">this should not be changed<br /><br /></p><p class="no-section">but here yes<br /></p><p class="no-section">here too</p>""".stripMargin
-    )
+    resultShouldBe(forReview(text),
+          """<p class="no-section">this is a first line</p><p class="no-section">this should not be changed<br /><br /></p><p class="no-section">but here yes<br /></p><p class="no-section">here too</p>""".stripMargin)
   }
 
   it should "be able to break pages" in {
@@ -1239,10 +853,8 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
       """first paragraph of text
       |\pagebreak
       |second paragraph of text""".stripMargin
-    resultShouldBe(
-      forReview(text),
-      """<p class="no-section">first paragraph of text<br /></p><p class="no-section"><hr class="pagebreak" /></p><p class="no-section">second paragraph of text</p>"""
-    )
+    resultShouldBe(forReview(text),
+      """<p class="no-section">first paragraph of text<br /></p><p class="no-section"><hr class="pagebreak" /></p><p class="no-section">second paragraph of text</p>""")
   }
 
   it should "be able to indent lines" in {
@@ -1252,10 +864,8 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
       |\indentsecond paragraph of text
       |
       |third paragraph of text""".stripMargin
-    resultShouldBe(
-      forReview(text),
-      """<p class="no-section">first paragraph of text</p><p class="no-section indent">second paragraph of text</p><p class="no-section">third paragraph of text</p>"""
-    )
+    resultShouldBe(forReview(text),
+      """<p class="no-section">first paragraph of text</p><p class="no-section indent">second paragraph of text</p><p class="no-section">third paragraph of text</p>""")
   }
 
   it should "be able to align lines centered" in {
@@ -1265,10 +875,8 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
       |\centeredsecond paragraph of text
       |
       |third paragraph of text""".stripMargin
-    resultShouldBe(
-      forReview(text),
-      """<p class="no-section">first paragraph of text</p><p class="no-section align-center">second paragraph of text</p><p class="no-section">third paragraph of text</p>"""
-    )
+    resultShouldBe(forReview(text),
+      """<p class="no-section">first paragraph of text</p><p class="no-section align-center">second paragraph of text</p><p class="no-section">third paragraph of text</p>""")
   }
 
   it should "be able to align lines to the right" in {
@@ -1278,10 +886,8 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
       |\rightsecond paragraph of text
       |
       |third paragraph of text""".stripMargin
-    resultShouldBe(
-      forReview(text),
-      """<p class="no-section">first paragraph of text</p><p class="no-section align-right">second paragraph of text</p><p class="no-section">third paragraph of text</p>"""
-    )
+    resultShouldBe(forReview(text),
+      """<p class="no-section">first paragraph of text</p><p class="no-section align-right">second paragraph of text</p><p class="no-section">third paragraph of text</p>""")
   }
 
   it should "be able to align lines to the right with three-quarters spacing" in {
@@ -1291,14 +897,12 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
       |\right-three-quarterssecond paragraph of text
       |
       |third paragraph of text""".stripMargin
-    resultShouldBe(
-      forReview(text),
-      """<p class="no-section">first paragraph of text</p><p class="no-section align-right-three-quarters">second paragraph of text</p><p class="no-section">third paragraph of text</p>"""
-    )
+    resultShouldBe(forReview(text),
+      """<p class="no-section">first paragraph of text</p><p class="no-section align-right-three-quarters">second paragraph of text</p><p class="no-section">third paragraph of text</p>""")
   }
 
   it should "clean the text if there is invisible variables in the middle" in {
-    val text =
+    val text=
       """this is a first line
         |
         |this should not be changed
@@ -1309,32 +913,26 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
         |
         |
         |here too""".stripMargin
-    resultShouldBe(
-      forReview(text),
-      """<p class="no-section">this is a first line</p><p class="no-section">this should not be changed<br /><br /></p><p class="no-section">but here yes<br /></p><p class="no-section">here too</p>""".stripMargin
-    )
+    resultShouldBe(forReview(text),
+      """<p class="no-section">this is a first line</p><p class="no-section">this should not be changed<br /><br /></p><p class="no-section">but here yes<br /></p><p class="no-section">here too</p>""".stripMargin)
   }
 
   it should "clean the text if there is a space before a dot" in {
-    val text =
+    val text=
       """this is a first line .
         |this is another line ...
         |even with multiple spaces      .""".stripMargin
 
-    resultShouldBe(
-      forReview(text),
-      """<p class="no-section">this is a first line.<br />this is another line ...<br />even with multiple spaces.</p>""".stripMargin
-    )
+    resultShouldBe(forReview(text),
+        """<p class="no-section">this is a first line.<br />this is another line ...<br />even with multiple spaces.</p>""".stripMargin)
   }
 
-  // this is the tricky handling for conditionals, make sure that this works properly
+ // this is the tricky handling for conditionals, make sure that this works properly
   it should "handle properly conditional blocks highlights with sections" in {
-    val text = """{{Try "try this logic" => ^ This is a test}}""".stripMargin
+    val text="""{{Try "try this logic" => ^ This is a test}}""".stripMargin
 
-    resultShouldBe(
-      forPreview(text, Map("Try" -> "true")),
-      """<div class="openlaw-paragraph paragraph-1"><p class="no-section"></p></div><ul class="list-lvl-1"><li><div class="openlaw-paragraph paragraph-2"><p>1.  This is a test</p></div></li></ul>"""
-    )
+    resultShouldBe(forPreview(text, Map("Try" -> "true")),
+    """<div class="openlaw-paragraph paragraph-1"><p class="no-section"></p></div><ul class="list-lvl-1"><li><div class="openlaw-paragraph paragraph-2"><p>1.  This is a test</p></div></li></ul>""")
   }
 
   it should "handle decimals in constants as well" in {
@@ -1342,12 +940,9 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
       """
         |[[#Variable1:Number(0.34)]]
         |[[@My Alias = Variable1 + 0.56]]
-        |[[My Alias | noTrailingZeros]]""".stripMargin.replaceAll("\n", "")
+        |[[My Alias | noTrailingZeros]]""".stripMargin.replaceAll("\n","")
 
-    resultShouldBe(
-      forReview(text, Map("Variable1" -> "0.34")),
-      """<p class="no-section">0.9</p>"""
-    )
+    resultShouldBe(forReview(text, Map("Variable1" -> "0.34")), """<p class="no-section">0.9</p>""")
   }
 
   it should "handle decimals in divisions" in {
@@ -1355,12 +950,9 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
       """
         |[[#Variable1:Number]]
         |[[@My Alias = (Variable1 / 100) * 4 ]]
-        |[[My Alias | noTrailingZeros]]""".stripMargin.replaceAll("\n", "")
+        |[[My Alias | noTrailingZeros]]""".stripMargin.replaceAll("\n","")
 
-    resultShouldBe(
-      forReview(text, Map("Variable1" -> "34")),
-      """<p class="no-section">1.36</p>"""
-    )
+    resultShouldBe(forReview(text, Map("Variable1" -> "34")), """<p class="no-section">1.36</p>""")
   }
 
   it should "be able to organize sections for variables" in {
@@ -1383,20 +975,10 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
     executeTemplate(text) match {
       case Right(executionResult) =>
         val sections = executionResult.sections
-        sections("My first section").map(_.name) should contain theSameElementsAs Seq(
-          "Variable 1",
-          "Variable 2"
-        )
-        sections("My second section").map(_.name) should contain theSameElementsAs Seq(
-          "Variable 3",
-          "Variable 4",
-          "Variable 5",
-          "Variable 6"
-        )
+        sections("My first section").map(_.name) should contain theSameElementsAs Seq("Variable 1", "Variable 2")
+        sections("My second section").map(_.name) should contain theSameElementsAs Seq("Variable 3", "Variable 4", "Variable 5", "Variable 6")
 
-        executionResult.getVariables
-          .map(_.name.name)
-          .toSet should contain theSameElementsAs Set(
+        executionResult.getVariables.map(_.name.name).toSet should contain theSameElementsAs Set(
           "Variable 1",
           "Variable 2",
           "Variable 3",
@@ -1409,8 +991,7 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
   }
 
   it should "not break a paragraph from a variable" in {
-    val source =
-      """Effective Date:  [[Effective Date: DateTime]]
+    val source = """Effective Date:  [[Effective Date: DateTime]]
                    |
                    |In consideration and as a condition of my employment, continued employment, or payment for services rendered as an independent contractor, consultant, or advisor ("Service Relationship") by [[Company]] {{Corporation "Is the company a corporation?" => , a [[StateOfIncorporation "What state is the first party incorporated in?"]] corporation, }} {{LLC "An LLC?" => a [[StateOfIncorporation "What state company incorporated in?"]] limited liability company, }} {{PBC "A Public Benefit Corporation?" => , a [[StateOfIncorporation "What state is the company incorporated in?"]] public benefit corporation, }}  or any of its current or future subsidiaries, affiliates, successors or assigns (collectively, the "Company"), and my receipt of compensation now and hereafter paid to me by the Company, I hereby agree as follows:
                    |
@@ -1418,18 +999,14 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
                    |
                    |^^	**Confidential Information.**  I agree that all information, whether or not in writing, concerning the Company’s business, technology, business relationships or financial affairs which the Company has not released to the general public (collectively, "Confidential Information") is and will be the exclusive property of the Company. By way of illustration, Confidential Information may include information or material which has not been made generally available to the public, such as: (i) corporate information, including plans, strategies, methods, policies, resolutions, negotiations, or litigation; (ii) marketing information, including strategies, methods, customer identities or other information about customers, prospect identities or other information about prospects, or market analyses or projections; (iii) financial information, including cost and performance data, debt arrangements, equity structure, investors and holdings, purchasing and sales data and price lists; and (d) operational and technological information, including plans, specifications, manuals, forms, templates, software, designs, methods, procedures, formulas, discoveries, inventions, improvements, concepts and ideas; and (e) personnel information, including personnel lists, reporting or organizational structure, resumes, personnel data, compensation structure, performance evaluations and termination arrangements or documents. Confidential Information also includes information received in confidence by the Company from its customers or suppliers or other third parties.
                    |
-                   |^^ **Nondisclosure; Recognition of Company’s Rights.**  I will not, at any time, without the Company’s prior written permission, either during or after my Service Relationship with the Company, disclose any Confidential Information to anyone outside of the Company, or use or permit to be used any Confidential Information for any purpose other than the performance of my duties as a Service Provider of the Company. I will cooperate with the Company and use my best efforts to prevent the unauthorized disclosure of all Proprietary Information. I will deliver to the Company all copies of Confidential Information in my possession or control upon the earlier of a request by the Company or termination of my service relationship with the Company."""
-        .stripMargin
+                   |^^ **Nondisclosure; Recognition of Company’s Rights.**  I will not, at any time, without the Company’s prior written permission, either during or after my Service Relationship with the Company, disclose any Confidential Information to anyone outside of the Company, or use or permit to be used any Confidential Information for any purpose other than the performance of my duties as a Service Provider of the Company. I will cooperate with the Company and use my best efforts to prevent the unauthorized disclosure of all Proprietary Information. I will deliver to the Company all copies of Confidential Information in my possession or control upon the earlier of a request by the Company or termination of my service relationship with the Company.""".stripMargin
 
-    (
-      forReview(source, Map(), ParagraphEdits(Map(2 -> "hello world"))),
-      """<p class="no-section">Effective Date:  [[Effective Date]]</p><p class="no-section">In consideration and as a condition of my employment, continued employment, or payment for services rendered as an independent contractor, consultant, or advisor ("Service Relationship") by [[Company]]     or any of its current or future subsidiaries, affiliates, successors or assigns (collectively, the "Company"), and my receipt of compensation now and hereafter paid to me by the Company, I hereby agree as follows:</p><ul class="list-lvl-1"><li><p>1. hello world</p><ul class="list-lvl-2"><li><p>(a) 	<strong>Confidential Information.</strong>  I agree that all information, whether or not in writing, concerning the Company’s business, technology, business relationships or financial affairs which the Company has not released to the general public (collectively, "Confidential Information") is and will be the exclusive property of the Company. By way of illustration, Confidential Information may include information or material which has not been made generally available to the public, such as: (i) corporate information, including plans, strategies, methods, policies, resolutions, negotiations, or litigation; (ii) marketing information, including strategies, methods, customer identities or other information about customers, prospect identities or other information about prospects, or market analyses or projections; (iii) financial information, including cost and performance data, debt arrangements, equity structure, investors and holdings, purchasing and sales data and price lists; and (d) operational and technological information, including plans, specifications, manuals, forms, templates, software, designs, methods, procedures, formulas, discoveries, inventions, improvements, concepts and ideas; and (e) personnel information, including personnel lists, reporting or organizational structure, resumes, personnel data, compensation structure, performance evaluations and termination arrangements or documents. Confidential Information also includes information received in confidence by the Company from its customers or suppliers or other third parties.</p></li><li><p>(b)  <strong>Nondisclosure; Recognition of Company’s Rights.</strong>  I will not, at any time, without the Company’s prior written permission, either during or after my Service Relationship with the Company, disclose any Confidential Information to anyone outside of the Company, or use or permit to be used any Confidential Information for any purpose other than the performance of my duties as a Service Provider of the Company. I will cooperate with the Company and use my best efforts to prevent the unauthorized disclosure of all Proprietary Information. I will deliver to the Company all copies of Confidential Information in my possession or control upon the earlier of a request by the Company or termination of my service relationship with the Company.</p></li></ul></li></ul>"""
-    )
+    (forReview(source, Map(),ParagraphEdits(Map(2 -> "hello world"))),
+    """<p class="no-section">Effective Date:  [[Effective Date]]</p><p class="no-section">In consideration and as a condition of my employment, continued employment, or payment for services rendered as an independent contractor, consultant, or advisor ("Service Relationship") by [[Company]]     or any of its current or future subsidiaries, affiliates, successors or assigns (collectively, the "Company"), and my receipt of compensation now and hereafter paid to me by the Company, I hereby agree as follows:</p><ul class="list-lvl-1"><li><p>1. hello world</p><ul class="list-lvl-2"><li><p>(a) 	<strong>Confidential Information.</strong>  I agree that all information, whether or not in writing, concerning the Company’s business, technology, business relationships or financial affairs which the Company has not released to the general public (collectively, "Confidential Information") is and will be the exclusive property of the Company. By way of illustration, Confidential Information may include information or material which has not been made generally available to the public, such as: (i) corporate information, including plans, strategies, methods, policies, resolutions, negotiations, or litigation; (ii) marketing information, including strategies, methods, customer identities or other information about customers, prospect identities or other information about prospects, or market analyses or projections; (iii) financial information, including cost and performance data, debt arrangements, equity structure, investors and holdings, purchasing and sales data and price lists; and (d) operational and technological information, including plans, specifications, manuals, forms, templates, software, designs, methods, procedures, formulas, discoveries, inventions, improvements, concepts and ideas; and (e) personnel information, including personnel lists, reporting or organizational structure, resumes, personnel data, compensation structure, performance evaluations and termination arrangements or documents. Confidential Information also includes information received in confidence by the Company from its customers or suppliers or other third parties.</p></li><li><p>(b)  <strong>Nondisclosure; Recognition of Company’s Rights.</strong>  I will not, at any time, without the Company’s prior written permission, either during or after my Service Relationship with the Company, disclose any Confidential Information to anyone outside of the Company, or use or permit to be used any Confidential Information for any purpose other than the performance of my duties as a Service Provider of the Company. I will cooperate with the Company and use my best efforts to prevent the unauthorized disclosure of all Proprietary Information. I will deliver to the Company all copies of Confidential Information in my possession or control upon the earlier of a request by the Company or termination of my service relationship with the Company.</p></li></ul></li></ul>""")
   }
 
   it should "compile this piece" in {
-    val text =
-      """"==Effective Date==
+    val text = """"==Effective Date==
               [[Effective Date: Date | date]]
 
                  ==Company Information -
@@ -1472,7 +1049,7 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
   }
 
   it should "work with employee offer letter" in {
-    val text =
+    val text  =
       """
         |**[[Company Name: Text | Uppercase]]**
         |[[Company Street]]
@@ -1490,11 +1067,10 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
         |
         |We're excited to offer you a position with""".stripMargin
 
-    resultShouldBe(
-      forReview(text, Map()),
-      """<p class="no-section"><br /><strong>[[Company Name]]</strong><br />[[Company Street]]<br />[[Company City]], [[Company State]] [[Company Zip]]</p><p class="no-section">[[Effective Date]]</p><p class="no-section">[[Employee First Name]] [[Employee Last Name]]<br />[[Employee Street]]<br />[[Employee City]], [[Employee State]] [[Employee Zip]]</p><p class="no-section"><strong>Re:  Offer Letter</strong></p><p class="no-section">Dear [[Employee First Name]]:</p><p class="no-section">We're excited to offer you a position with</p>""".stripMargin
-    )
+    resultShouldBe(forReview(text,Map()),
+      """<p class="no-section"><br /><strong>[[Company Name]]</strong><br />[[Company Street]]<br />[[Company City]], [[Company State]] [[Company Zip]]</p><p class="no-section">[[Effective Date]]</p><p class="no-section">[[Employee First Name]] [[Employee Last Name]]<br />[[Employee Street]]<br />[[Employee City]], [[Employee State]] [[Employee Zip]]</p><p class="no-section"><strong>Re:  Offer Letter</strong></p><p class="no-section">Dear [[Employee First Name]]:</p><p class="no-section">We're excited to offer you a position with</p>""".stripMargin)
   }
+
 
   it should "be able to override paragraphs" in {
     val text =
@@ -1505,14 +1081,7 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
         |and this is too
       """.stripMargin
 
-    resultShouldBe(
-      forReview(
-        text = text,
-        paragraphs =
-          ParagraphEdits(Map(2 -> "now I want this new text [[My Variable]]"))
-      ),
-      """<p class="no-section">hello my friend</p><ul class="list-lvl-1"><li><p>1.  this is a new paragraph [[My Variable]]</p><p>now I want this new text [[My Variable]]</p></li></ul>"""
-    )
+    resultShouldBe(forReview(text = text, paragraphs = ParagraphEdits(Map(2 -> "now I want this new text [[My Variable]]"))), """<p class="no-section">hello my friend</p><ul class="list-lvl-1"><li><p>1.  this is a new paragraph [[My Variable]]</p><p>now I want this new text [[My Variable]]</p></li></ul>""")
   }
 
   it should "not highlist identity variables" in {
@@ -1524,10 +1093,7 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
         |Test
       """.stripMargin
 
-    resultShouldBe(
-      forPreview(text = text, params = Map()),
-      """<div class="openlaw-paragraph paragraph-1"><p class="no-section"><br /></p></div><div class="openlaw-paragraph paragraph-2"><p class="no-section">_______________________<br />Test<br />      </p></div>"""
-    )
+    resultShouldBe(forPreview(text = text, params = Map()), """<div class="openlaw-paragraph paragraph-1"><p class="no-section"><br /></p></div><div class="openlaw-paragraph paragraph-2"><p class="no-section">_______________________<br />Test<br />      </p></div>""")
   }
 
   it should "not eat some of the content" in {
@@ -1545,10 +1111,7 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
         |By: [[Contractor First Name]] [[Contractor Last Name]]
       """.stripMargin
 
-    resultShouldBe(
-      forReview(text = text, params = Map()),
-      """<p class="no-section"><br /></p><p class="no-section">_______________________<br />Joseph Lubin, Mitglied des Verwaltungsrates (Board Member) ConsenSys AG</p><p class="no-section">On behalf of the Contractor:</p><p class="no-section"><br />_______________________<br />By: [[Contractor First Name]] [[Contractor Last Name]]<br />      </p>"""
-    )
+    resultShouldBe(forReview(text = text, params = Map()), """<p class="no-section"><br /></p><p class="no-section">_______________________<br />Joseph Lubin, Mitglied des Verwaltungsrates (Board Member) ConsenSys AG</p><p class="no-section">On behalf of the Contractor:</p><p class="no-section"><br />_______________________<br />By: [[Contractor First Name]] [[Contractor Last Name]]<br />      </p>""")
   }
 
   it should "give you the list of used variables in the template" in {
@@ -1563,9 +1126,7 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
 
     executeTemplate(text) match {
       case Right(executionResult) =>
-        executionResult.getAllExecutedVariables.map({
-          case (_, name) => name.name
-        }) shouldBe Seq("var1")
+        executionResult.getAllExecutedVariables.map({case (_, name) => name.name}) shouldBe Seq("var1")
       case Left(ex) => fail(ex)
     }
 
@@ -1583,9 +1144,7 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
 
     executeTemplate(text) match {
       case Right(executionResult) =>
-        executionResult.getAllExecutedVariables.map({
-          case (_, name) => name.name
-        }) shouldBe Seq("var1", "var2")
+        executionResult.getAllExecutedVariables.map({case (_, name) => name.name}) shouldBe Seq("var1", "var2")
       case Left(ex) => fail(ex)
     }
   }
@@ -1603,9 +1162,7 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
 
     executeTemplate(text) match {
       case Right(executionResult) =>
-        executionResult.getAllExecutedVariables.map({
-          case (_, name) => name.name
-        }) shouldBe Seq("var1", "var2")
+        executionResult.getAllExecutedVariables.map({case (_, name) => name.name}) shouldBe Seq("var1", "var2")
       case Left(ex) => fail(ex)
     }
   }
@@ -1619,13 +1176,11 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
         |{{(var1 > 10) && (var2 > 20) => iuhiuhuih}}
         |""".stripMargin
 
-    executeTemplate(text, Map("var1" -> "5", "var2" -> "40")) match {
-      case Right(executionResult) =>
-        executionResult.getAllExecutedVariables.map({
-          case (_, name) => name.name
-        }) shouldBe Seq("var1")
-      case Left(ex) => fail(ex)
-    }
+      executeTemplate(text, Map("var1" -> "5" , "var2" -> "40")) match {
+        case Right(executionResult) =>
+          executionResult.getAllExecutedVariables.map({case (_, name) => name.name}) shouldBe Seq("var1")
+        case Left(ex) => fail(ex)
+      }
   }
 
   it should "not seen the right part of an expression as executed if it should not with 'or'" in {
@@ -1637,11 +1192,10 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
         |{{(var1 > 10) || (var2 > 20) => hihiuhuih }}
         |""".stripMargin
 
-    executeTemplate(text, Map("var1" -> "25", "var2" -> "40")) match {
+
+    executeTemplate(text, Map("var1" -> "25" , "var2" -> "40")) match {
       case Right(executionResult) =>
-        executionResult.getAllExecutedVariables.map({
-          case (_, name) => name.name
-        }) shouldBe Seq("var1")
+        executionResult.getAllExecutedVariables.map({case (_, name) => name.name}) shouldBe Seq("var1")
       case Left(ex) => fail(ex)
     }
   }
@@ -1655,11 +1209,10 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
         |{{((var1 > 10) || (var2 > 20)) hihiuhuih }}
         |""".stripMargin
 
-    executeTemplate(text, Map("var1" -> "25", "var2" -> "40")) match {
+
+    executeTemplate(text, Map("var1" -> "25" , "var2" -> "40")) match {
       case Right(executionResult) =>
-        executionResult.getAllExecutedVariables.map({
-          case (_, name) => name.name
-        }) shouldBe Seq("var1")
+        executionResult.getAllExecutedVariables.map({case (_, name) => name.name}) shouldBe Seq("var1")
       case Left(ex) => fail(ex)
     }
   }
@@ -1675,76 +1228,48 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
   }
 
   it should "take the default value expression if none has been specified" in {
-    val text =
-      """[[My Number:Number(12)]][[My Number 2:Number(My Number + 10)]]""".stripMargin
+    val text = """[[My Number:Number(12)]][[My Number 2:Number(My Number + 10)]]""".stripMargin
 
     resultShouldBe(forReview(text, Map()), """<p class="no-section">1222</p>""")
   }
 
   it should "read a property from an address" in {
-    val text = "<%[[My Address:Address]]%>[[My Address.country]]"
+    val text ="<%[[My Address:Address]]%>[[My Address.country]]"
 
-    resultShouldBe(
-      forReview(
-        text,
-        Map(
-          "My Address" -> AddressType
-            .internalFormat(
-              Address(
-                city = "a certain city",
-                state = "a state",
-                country = "United States",
-                zipCode = "102030392",
-                formattedAddress = "some kind of formatted address"
-              )
-            )
-            .right
-            .value
-        )
-      ),
-      """<p class="no-section">United States</p>"""
-    )
+    resultShouldBe(forReview(text, Map("My Address" -> AddressType.internalFormat(Address(
+      city = "a certain city",
+      state = "a state",
+      country = "United States",
+      zipCode = "102030392",
+      formattedAddress = "some kind of formatted address"
+    )).right.value)), """<p class="no-section">United States</p>""")
   }
 
   it should "validate and make sure you do not use an invalid property" in {
-    val text = "<%[[My Address:Address]]%>[[My Address.badProperty]]"
+    val text ="<%[[My Address:Address]]%>[[My Address.badProperty]]"
 
     structureAgreement(text) match {
       case Right(_) => fail("should fail")
-      case Left(msg) =>
-        msg.message shouldBe "property 'badProperty' not found for type Address"
+      case Left(msg) => msg.message shouldBe "property 'badProperty' not found for type Address"
     }
   }
 
   it should "round number" in {
-    val text = "<%[[My Number:Number]]%>[[My Number | rounding(2)]]"
+    val text ="<%[[My Number:Number]]%>[[My Number | rounding(2)]]"
 
-    resultShouldBe(
-      forReview(text, Map("My Number" -> "0.33333333333")),
-      """<p class="no-section">0.33</p>"""
-    )
+    resultShouldBe(forReview(text, Map("My Number" -> "0.33333333333")),"""<p class="no-section">0.33</p>""")
   }
 
   it should "format number" in {
-    val text = "<%[[My Number:Number]]%>[[My Number]]"
+    val text ="<%[[My Number:Number]]%>[[My Number]]"
 
-    resultShouldBe(
-      forReview(text, Map("My Number" -> "1000000000")),
-      """<p class="no-section">1,000,000,000</p>"""
-    )
+    resultShouldBe(forReview(text, Map("My Number" -> "1000000000")),"""<p class="no-section">1,000,000,000</p>""")
   }
 
   it should "round number with expression" in {
-    val text =
-      "<%[[My Number:Number]] [[Rounding Number:Number]]%>[[My Number | rounding(Rounding Number)]]"
+    val text ="<%[[My Number:Number]] [[Rounding Number:Number]]%>[[My Number | rounding(Rounding Number)]]"
 
-    resultShouldBe(
-      forReview(
-        text,
-        Map("My Number" -> "0.333333333333333", "Rounding Number" -> "2")
-      ),
-      """<p class="no-section">0.33</p>"""
-    )
+    resultShouldBe(forReview(text, Map("My Number" -> "0.333333333333333", "Rounding Number" -> "2")), """<p class="no-section">0.33</p>""")
   }
 
   it should "handle validation" in {
@@ -1761,9 +1286,7 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
 
     executeTemplate(text, Map("My Number" -> "3")) match {
       case Right(executionResult) =>
-        executionResult.validate.toResult.left.value.message should be(
-          "My Number needs to be higher than 5"
-        )
+        executionResult.validate.toResult.left.value.message should be("My Number needs to be higher than 5")
       case Left(ex) => fail(ex.message, ex)
     }
   }
@@ -1779,33 +1302,24 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
          [[amount:Amount]]
       """.stripMargin
 
-    executeTemplate(text) match {
+     executeTemplate(text) match {
       case Success(executionResult) =>
         executionResult.findVariableType(VariableTypeDefinition("Amount")) match {
           case Some(domainType: DefinedDomainType) => domainType.domain
-          case Some(variableType) =>
-            fail(s"invalid variable type ${variableType.thisType}")
+          case Some(variableType) => fail(s"invalid variable type ${variableType.thisType}")
           case None => fail("domain type is not the right type")
         }
       case Failure(ex, message) =>
         fail(message, ex)
     }
 
-    executeTemplate(text) match {
+     executeTemplate(text) match {
       case Right(executionResult) =>
         executionResult.findVariableType(VariableTypeDefinition("Amount")) match {
           case Some(_: DefinedDomainType) =>
-            val Right(newExecutionResult) =
-              executeTemplate(text, Map("amount" -> "5"))
-            service
-              .parseExpression("amount")
-              .flatMap(_.evaluate(newExecutionResult))
-              .right
-              .value
-              .value
-              .toString shouldBe "5"
-          case Some(variableType) =>
-            fail(s"invalid variable type ${variableType.thisType}")
+            val Right(newExecutionResult) = executeTemplate(text, Map("amount" -> "5"))
+            service.parseExpression("amount").flatMap(_.evaluate(newExecutionResult)).right.value.value.toString shouldBe "5"
+          case Some(variableType) => fail(s"invalid variable type ${variableType.thisType}")
           case None => fail("domain type is not the right type")
         }
       case Left(ex) =>
@@ -1816,13 +1330,9 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
       case Right(executionResult) =>
         executionResult.findVariableType(VariableTypeDefinition("Amount")) match {
           case Some(domainType: DefinedDomainType) =>
-            val Right(newExecutionResult) =
-              executeTemplate(text, Map("amount" -> "-5"))
-            newExecutionResult.validate.toResult.left.value.message should be(
-              "amount must be greater than 0!"
-            )
-          case Some(variableType) =>
-            fail(s"invalid variable type ${variableType.thisType}")
+            val Right(newExecutionResult) = executeTemplate(text, Map("amount" -> "-5"))
+            newExecutionResult.validate.toResult.left.value.message should be("amount must be greater than 0!")
+          case Some(variableType) => fail(s"invalid variable type ${variableType.thisType}")
           case None => fail("domain type is not the right type")
         }
       case Left(ex) =>
@@ -1830,9 +1340,9 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
     }
   }
 
-  it should "make it possible to do expressions with domain types (and the expressions need to be validated too)" in {
-    val text =
-      """
+	it should "make it possible to do expressions with domain types (and the expressions need to be validated too)" in {
+		val text =
+			"""
         [[Amount:DomainType(
 				|variableType: Number;
 				|condition: this > 0;
@@ -1844,20 +1354,20 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
 				|[[amount expression]]
       """.stripMargin
 
-    executeTemplate(text, Map("amount" -> "10", "amount2" -> "2")) match {
-      case Success(executionResult) =>
-        executionResult.validate.isValid shouldBe true
-      case Failure(ex, message) =>
-        fail(message, ex)
-    }
+		executeTemplate(text, Map("amount" -> "10", "amount2" -> "2" )) match {
+			case Success(executionResult) =>
+				executionResult.validate.isValid shouldBe true
+			case Failure(ex, message) =>
+				fail(message, ex)
+		}
 
-    executeTemplate(text, Map("amount" -> "10", "amount2" -> "12")) match {
-      case Success(executionResult) =>
-        executionResult.validate.toResult.left.value.message shouldBe "amount must be greater than 0!"
-      case Failure(ex, message) =>
-        fail(message, ex)
-    }
-  }
+		executeTemplate(text, Map("amount" -> "10", "amount2" -> "12" )) match {
+			case Success(executionResult) =>
+				executionResult.validate.toResult.left.value.message shouldBe "amount must be greater than 0!"
+			case Failure(ex, message) =>
+				fail(message, ex)
+		}
+	}
 
   it should "verify that conditionals are of the correct type" in {
     val text =
@@ -1869,8 +1379,7 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
     structureAgreement(text) match {
       case Right(_) =>
         fail("should fail")
-      case Left(ex) =>
-        ex.message shouldBe "Conditional expression number + 401 is of type NumberType instead of YesNo"
+      case Left(ex) => ex.message shouldBe "Conditional expression number + 401 is of type NumberType instead of YesNo"
     }
   }
 
@@ -1881,10 +1390,7 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
          [[my city:City]]
          %>{{ my city = "Zurich" => hello world}}""".stripMargin
 
-    resultShouldBe(
-      forReview(text, Map("my city" -> "Zurich")),
-      """<p class="no-section">hello world</p>"""
-    )
+    resultShouldBe(forReview(text, Map("my city" -> "Zurich")), """<p class="no-section">hello world</p>""")
   }
 
   it should "throw an exception if we have an unknown type" in {
@@ -1908,14 +1414,10 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
          [[option:Options]]
       """.stripMargin
 
+
     executeTemplate(text, Map("option" -> "two")) match {
       case Right(executionResult) =>
-        executionResult
-          .getVariableValue[OpenlawString](VariableName("option"))
-          .right
-          .value
-          .value
-          .underlying shouldBe "two"
+        executionResult.getVariableValue[OpenlawString](VariableName("option")).right.value.value.underlying shouldBe "two"
       case Left(ex) =>
         fail(ex)
     }
@@ -1944,34 +1446,11 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
 
     executeTemplate(text) match {
       case Right(executionResult) =>
-        val structureType = executionResult
-          .findVariableType(VariableTypeDefinition("Name"))
-          .getOrElse(NumberType)
+        val structureType = executionResult.findVariableType(VariableTypeDefinition("Name")).getOrElse(NumberType)
         structureType === NumberType shouldBe false
-        val newExecutionResult = executeTemplate(
-          text,
-          Map(
-            "name1" -> structureType
-              .internalFormat(
-                OpenlawMap(
-                  Map(
-                    VariableName("first") -> OpenlawString("John"),
-                    VariableName("last") -> OpenlawString("Doe")
-                  )
-                )
-              )
-              .right
-              .value
-          )
-        ).right.value
+        val newExecutionResult = executeTemplate(text, Map("name1" -> structureType.internalFormat(OpenlawMap(Map(VariableName("first") -> OpenlawString("John"), VariableName("last") -> OpenlawString("Doe")))).right.value)).right.value
 
-        service
-          .parseExpression("name1.first")
-          .flatMap(_.evaluate(newExecutionResult))
-          .right
-          .value
-          .value
-          .toString shouldBe "John"
+        service.parseExpression("name1.first").flatMap(_.evaluate(newExecutionResult)).right.value.value.toString shouldBe "John"
       case Left(ex) =>
         fail(ex)
     }
@@ -1985,30 +1464,18 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
          [[@My Id = address.placeId]]
       """.stripMargin
 
-    executeTemplate(
-      text,
-      Map(
-        "address" -> AddressType
-          .internalFormat(
-            Address(
-              placeId = "placeId",
-              streetName = "streetName",
-              streetNumber = "streetNumber",
-              city = "city",
-              state = "state ",
-              country = "Country",
-              zipCode = "zipCode",
-              formattedAddress = "formattedAddress"
-            )
-          )
-          .right
-          .value
-      )
-    ) match {
+    executeTemplate(text, Map("address" -> AddressType.internalFormat(Address(
+      placeId = "placeId",
+      streetName = "streetName",
+      streetNumber = "streetNumber",
+      city = "city",
+      state = "state ",
+      country = "Country",
+      zipCode = "zipCode",
+      formattedAddress = "formattedAddress"
+    )).right.value)) match {
       case Right(executionResult) =>
-        val result = executionResult
-          .getAlias("My Id")
-          .flatMap(_.evaluate(executionResult).right.value)
+        val result = executionResult.getAlias("My Id").flatMap(_.evaluate(executionResult).right.value)
         result.value.toString shouldBe "placeId"
       case Left(ex) => fail(ex)
     }
@@ -2026,9 +1493,7 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
         val variableDefinition = executionResult.getVariables.head
 
         variableDefinition.name.name shouldBe "My Conditional"
-        variableDefinition.variableTypeDefinition.map(_.name) shouldBe Some(
-          YesNoType.name
-        )
+        variableDefinition.variableTypeDefinition.map(_.name) shouldBe Some(YesNoType.name)
         variableDefinition.description shouldBe Some("this is a question")
       case Failure(ex, message) => fail(message, ex)
     }
@@ -2050,14 +1515,10 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
 
     executeTemplate(text, Map("BV" -> "true", "My Conditional" -> "true")) match {
       case Success(executionResult) =>
-        val variableDefinition = executionResult.getVariables
-          .filter(_.name.name === "My Conditional")
-          .head
+        val variableDefinition = executionResult.getVariables.filter(_.name.name === "My Conditional").head
 
         variableDefinition.name.name shouldBe "My Conditional"
-        variableDefinition.variableTypeDefinition.map(_.name) shouldBe Some(
-          YesNoType.name
-        )
+        variableDefinition.variableTypeDefinition.map(_.name) shouldBe Some(YesNoType.name)
         variableDefinition.description shouldBe Some("this is a question")
       case Failure(ex, message) => fail(message, ex)
     }
@@ -2122,24 +1583,12 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
 
     executeTemplate(text, Map()) match {
       case Right(executionResult) =>
-        executionResult.getAllExecutedVariables.map({
-          case (_, name) => name.name
-        }) shouldBe Seq(
-          "Additional Agreements",
-          "Corporation",
-          "LLC",
-          "PBC",
-          "Stock Award"
-        )
+        executionResult.getAllExecutedVariables.map({case (_, name) => name.name}) shouldBe Seq("Additional Agreements" ,"Corporation", "LLC", "PBC", "Stock Award")
 
         executionResult.getVariable("Dispute Resolution") match {
           case Some(variable) =>
-            variable.variableTypeDefinition.map(_.name) shouldBe Some(
-              YesNoType.name
-            )
-            variable.description shouldBe Some(
-              "An Alternative Dispute Resolution Agreement?"
-            )
+            variable.variableTypeDefinition.map(_.name) shouldBe Some(YesNoType.name)
+            variable.description shouldBe Some("An Alternative Dispute Resolution Agreement?")
           case None =>
             fail("Dispute Resolution not found!")
         }
@@ -2161,9 +1610,7 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
 
     executeTemplate(text) match {
       case Success(executionResult) =>
-        executionResult.getAllExecutedVariables.map({
-          case (_, name) => name.name
-        }) shouldBe Seq("Conditional")
+        executionResult.getAllExecutedVariables.map({case (_, name) => name.name}) shouldBe Seq("Conditional")
       case Failure(ex, message) =>
         fail(message, ex)
     }
@@ -2172,10 +1619,7 @@ class OpenlawTemplateLanguageParserSpec extends FlatSpec with Matchers {
   it should "parse [ and ] as characters if it is not the right variable format" in {
     val text = "[this is some text]"
 
-    resultShouldBe(
-      forReview(text),
-      """<p class="no-section">[this is some text]</p>"""
-    )
+    resultShouldBe(forReview(text), """<p class="no-section">[this is some text]</p>""")
   }
 
   it should "be able to define a header in the template" in {
@@ -2246,13 +1690,9 @@ here""".stripMargin
 
     val inputStructureType = executeTemplate(inputStructureText) match {
       case Success(executionResult) =>
-        executionResult.findVariableType(
-          VariableTypeDefinition("FakeServiceInput")
-        ) match {
-          case Some(structureType: DefinedStructureType) =>
-            structureType.structure
-          case Some(variableType) =>
-            fail(s"invalid variable type ${variableType.thisType}")
+        executionResult.findVariableType(VariableTypeDefinition("FakeServiceInput")) match {
+          case Some(structureType: DefinedStructureType) => structureType.structure
+          case Some(variableType) => fail(s"invalid variable type ${variableType.thisType}")
           case None => fail("structure type is not the right type")
         }
       case Failure(ex, message) =>
@@ -2268,13 +1708,9 @@ here""".stripMargin
 
     val outputStructureType = executeTemplate(outputStructureText) match {
       case Success(executionResult) =>
-        executionResult.findVariableType(
-          VariableTypeDefinition("FakeServiceOutput")
-        ) match {
-          case Some(structureType: DefinedStructureType) =>
-            structureType.structure
-          case Some(variableType) =>
-            fail(s"invalid variable type ${variableType.thisType}")
+        executionResult.findVariableType(VariableTypeDefinition("FakeServiceOutput")) match {
+          case Some(structureType:DefinedStructureType) => structureType.structure
+          case Some(variableType) => fail(s"invalid variable type ${variableType.thisType}")
           case None => fail("structure type is not the right type")
         }
       case Failure(ex, m) =>
@@ -2296,39 +1732,20 @@ here""".stripMargin
          |[[myExternalCall]]
       """.stripMargin
 
-    executeTemplate(
-      input,
-      Map("param1" -> "5", "param2" -> "5"),
-      Map(),
-      Map(
-        ServiceName("FakeServiceInput") -> IntegratedServiceDefinition(
-          inputStructureType,
-          outputStructureType
-        )
-      )
-    ) match {
+    executeTemplate(input, Map("param1" -> "5", "param2" -> "5"), Map(),
+      Map(ServiceName("FakeServiceInput") -> IntegratedServiceDefinition(inputStructureType, outputStructureType))) match {
       case Right(executionResult) =>
-        val externalCallType = executionResult.findVariableType(
-          VariableTypeDefinition("ExternalCall")
-        ) match {
-          case Some(variableType) => variableType
-          case None               => fail("structure type is not the right type")
+        val externalCallType = executionResult.findVariableType(VariableTypeDefinition("ExternalCall")) match {
+            case Some(variableType) => variableType
+            case None => fail("structure type is not the right type")
         }
         externalCallType shouldBe ExternalCallType
         val allActions = executionResult.allActions.getOrThrow()
         allActions.size shouldBe 1
 
-        val call = executionResult
-          .getVariableValues[ExternalCall](ExternalCallType)
-          .getOrThrow()
-          .head
-        call.serviceName
-          .asInstanceOf[StringConstant]
-          .value shouldBe "FakeServiceInput"
-        call.parameters.map(_.toString) shouldBe List(
-          "(param1,var1)",
-          "(param2,var2)"
-        )
+        val call = executionResult.getVariableValues[ExternalCall](ExternalCallType).getOrThrow().head
+        call.serviceName.asInstanceOf[StringConstant].value shouldBe "FakeServiceInput"
+        call.parameters.map(_.toString) shouldBe List("(param1,var1)", "(param2,var2)")
         call.startDate.map(_.toString) shouldBe Some("\"2018-12-12 00:00:00\"")
         call.endDate.map(_.toString) shouldBe Some("\"2048-12-12 00:00:00\"")
         call.every.map(_.toString) shouldBe Some("\"1 hour 30 minutes\"")
@@ -2346,13 +1763,9 @@ here""".stripMargin
     executeTemplate(text) match {
       case Success(executionResult) =>
         val Success(validationResult) = executionResult.validateExecution
-        validationResult.missingIdentities shouldBe Seq(
-          VariableName("Signatory")
-        )
+        validationResult.missingIdentities shouldBe Seq(VariableName("Signatory"))
         validationResult.missingInputs shouldBe Seq(VariableName("Signatory"))
-        executionResult.allMissingInput shouldBe Right(
-          Seq(VariableName("Signatory"))
-        )
+        executionResult.allMissingInput shouldBe Right(Seq(VariableName("Signatory")))
       case Failure(ex, message) =>
         fail(message, ex)
     }
@@ -2367,9 +1780,7 @@ here""".stripMargin
 
     executeTemplate(text) match {
       case Right(_) =>
-        fail(
-          "Empty 'serviceName' name value shouldn't be allowed in the template execution"
-        )
+        fail("Empty 'serviceName' name value shouldn't be allowed in the template execution")
       case Left(ex) =>
         ex.getMessage shouldBe "Invalid 'serviceName' property for ExternalSignature"
     }
@@ -2382,24 +1793,13 @@ here""".stripMargin
         |Test simple template
       """.stripMargin
 
-    executeTemplate(
-      text,
-      Map(),
-      Map(),
-      Map(
-        ServiceName("MyService") -> IntegratedServiceDefinition.signatureDefinition
-      )
-    ) match {
+    executeTemplate(text, Map(), Map(), Map(ServiceName("MyService") -> IntegratedServiceDefinition.signatureDefinition)) match {
       case Right(executionResult) =>
         val Success(validationResult) = executionResult.validateExecution
-        validationResult.missingIdentities shouldBe Seq(
-          VariableName("Signatory")
-        )
+        validationResult.missingIdentities shouldBe Seq(VariableName("Signatory"))
         validationResult.missingInputs shouldBe Seq(VariableName("Signatory"))
         validationResult.validationExpressionErrors shouldBe Seq()
-        executionResult.allMissingInput shouldBe Right(
-          Seq(VariableName("Signatory"))
-        )
+        executionResult.allMissingInput shouldBe Right(Seq(VariableName("Signatory")))
       case Failure(ex, message) =>
         fail(message, ex)
     }
@@ -2520,5 +1920,4 @@ here""".stripMargin
         fail(message, ex)
     }
   }
-
 }

--- a/shared/src/test/scala/org/adridadou/openlaw/parser/OpenlawTemplateLanguageParserSpec.scala
+++ b/shared/src/test/scala/org/adridadou/openlaw/parser/OpenlawTemplateLanguageParserSpec.scala
@@ -2405,10 +2405,10 @@ here""".stripMargin
     }
   }
 
-  it should "create a new variable type ExternalStorage" in {
+  it should "create a new variable type ExternalStorage for Dropbox with a docx file path" in {
     val text =
       """
-        |[[Dropbox Storage: ExternalStorage(serviceName:"Dropbox"; fileType:"doc"; filePath:"/openlaw/files/Test.doc")]]
+        |[[Dropbox Storage: ExternalStorage(serviceName:"Dropbox"; docx:"/openlaw/files/Test.doc")]]
         |Test simple template
       """.stripMargin
 
@@ -2430,10 +2430,9 @@ here""".stripMargin
         storage.serviceName
           .asInstanceOf[StringConstant]
           .value shouldBe "Dropbox"
-        storage.fileType.asInstanceOf[StringConstant].value shouldBe "doc"
         storage.filePath
-          .asInstanceOf[StringConstant]
-          .value shouldBe "/openlaw/files/Test.doc"
+          .asInstanceOf[TemplatePath]
+          .path shouldBe List("/openlaw/files/Test.doc")
       case Failure(ex, message) =>
         fail(message, ex)
     }


### PR DESCRIPTION
Adds a new variable type called: `ExternalStorage`. With this new type we can declare in Markup Language external storage providers (e.g: Dropbox, GoogleDrive, etc) to store OpenLaw agreements using different formats and paths.

Usage:
```
 [[Dropbox Storage: ExternalStorage(serviceName:"Dropbox"; docx:"/openlaw/files/Test.doc")]]

 [[Google Drive Storage: ExternalStorage(serviceName:"Google"; pdf:"/openlaw/files/Test.pdf")]]
```
The most common text file formats are supported in the file path declaration: `doc, docx, odt, pdf, rtf`.
