### PR TITLE
update Maven Central endpoint

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ lazy val scalaTestV = "3.2.0-SNAP10"
 
 lazy val repositories = Seq(
   Resolver.jcenterRepo,
-  "central" at "http://central.maven.org/maven2/",
+  "central" at "https://repo1.maven.org/maven2/",
   "scalaz-bintray" at "https://dl.bintray.com/scalaz/releases",
   "maven central" at "https://mvnrepository.com/repos/central",
   Resolver.mavenLocal


### PR DESCRIPTION
Fixes issue where `central.maven.org` is no longer resolving.

More details about the breaking changes with the repository endpoints:
https://central.sonatype.org/articles/2019/Nov/15/non-canonical-urls-will-be-redirected-today/
https://central.sonatype.org/articles/2018/Dec/17/ssl-endpoints/