### PR TITLE
fixing how we calculate "now" to be when we run the execution. This r…

### DIFF
--- a/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/EthereumSmartContractCall.scala
+++ b/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/EthereumSmartContractCall.scala
@@ -198,7 +198,10 @@ final case class EthereumSmartContractCall(
               case Nil =>
                 Some(
                   getStartDate(executionResult)
-                    .map(_.getOrElse(LocalDateTime.now(executionResult.clock)))
+                    .map(
+                      _.orElse(executionResult.info.creationDate)
+                        .getOrElse(executionResult.info.now)
+                    )
                 )
               case list =>
                 val lastDate = list.maxBy(_.toEpochSecond(ZoneOffset.UTC))

--- a/shared/src/main/scala/org/adridadou/openlaw/values/ContractDefinition.scala
+++ b/shared/src/main/scala/org/adridadou/openlaw/values/ContractDefinition.scala
@@ -1,5 +1,7 @@
 package org.adridadou.openlaw.values
 
+import java.time.LocalDateTime
+
 import org.adridadou.openlaw.oracles.{CryptoService, UserId}
 import org.adridadou.openlaw.parser.contract.ParagraphEdits
 import org.adridadou.openlaw.parser.template.variableTypes.{
@@ -10,9 +12,10 @@ import org.adridadou.openlaw.parser.template.variableTypes.{
 final case class ContractDefinition(
     creatorId: UserId = UserId.SYSTEM_ID,
     mainTemplate: TemplateId,
-    templates: Map[TemplateSourceIdentifier, TemplateId] = Map(),
+    templates: Map[TemplateSourceIdentifier, TemplateId] = Map.empty,
     parameters: TemplateParameters,
-    paragraphs: Map[Int, ParagraphEdits] = Map()
+    paragraphs: Map[Int, ParagraphEdits] = Map.empty,
+    creationDate: LocalDateTime = LocalDateTime.now
 ) {
 
   def id(crypto: CryptoService): ContractId =

--- a/shared/src/main/scala/org/adridadou/openlaw/vm/OpenlawExecutionEngine.scala
+++ b/shared/src/main/scala/org/adridadou/openlaw/vm/OpenlawExecutionEngine.scala
@@ -1,5 +1,6 @@
 package org.adridadou.openlaw.vm
 
+import java.time.LocalDateTime
 import java.util.concurrent.atomic.AtomicInteger
 
 import org.adridadou.openlaw.result._
@@ -23,10 +24,11 @@ class OpenlawExecutionEngine extends VariableExecutionEngine {
     execute(
       mainTemplate,
       TemplateParameters(),
-      Map(),
-      Map(),
-      Map(),
-      Map(),
+      Map.empty,
+      Map.empty,
+      Map.empty,
+      Map.empty,
+      None,
       None,
       None
     )
@@ -38,7 +40,17 @@ class OpenlawExecutionEngine extends VariableExecutionEngine {
       mainTemplate: CompiledTemplate,
       parameters: TemplateParameters
   ): Result[OpenlawExecutionState] =
-    execute(mainTemplate, parameters, Map(), Map(), Map(), Map(), None, None)
+    execute(
+      mainTemplate,
+      parameters,
+      Map.empty,
+      Map.empty,
+      Map.empty,
+      Map.empty,
+      None,
+      None,
+      None
+    )
 
   /**
     * Entry point. This is where you start the execution of the main template
@@ -54,9 +66,10 @@ class OpenlawExecutionEngine extends VariableExecutionEngine {
       mainTemplate,
       parameters,
       templates,
-      Map(),
-      Map(),
+      Map.empty,
+      Map.empty,
       externalCallStructures,
+      None,
       None,
       None
     )
@@ -69,12 +82,18 @@ class OpenlawExecutionEngine extends VariableExecutionEngine {
       executions: Map[ActionIdentifier, Executions],
       externalCallStructures: Map[ServiceName, IntegratedServiceDefinition],
       id: Option[ContractId],
+      creationDate: Option[LocalDateTime],
       profileAddress: Option[EthereumAddress]
   ): Result[OpenlawExecutionState] = {
     val executionResult = OpenlawExecutionState(
       parameters = parameters,
       id = TemplateExecutionResultId("@@anonymous_main_template_id@@"),
-      info = OLInformation(id = id, profileAddress = profileAddress),
+      info = OLInformation(
+        id = id,
+        profileAddress = profileAddress,
+        creationDate = creationDate,
+        now = LocalDateTime.now(mainTemplate.clock)
+      ),
       template = mainTemplate,
       executions = executions,
       anonymousVariableCounter = new AtomicInteger(0),

--- a/shared/src/main/scala/org/adridadou/openlaw/vm/OpenlawVm.scala
+++ b/shared/src/main/scala/org/adridadou/openlaw/vm/OpenlawVm.scala
@@ -195,6 +195,7 @@ final case class OpenlawVmState(
           executions,
           externalCallStructures,
           Some(definition.id(crypto)),
+          Some(definition.creationDate),
           profileAddress
         )
       ) match {

--- a/shared/src/test/scala/org/adridadou/openlaw/vm/OpenlawVmSpec.scala
+++ b/shared/src/test/scala/org/adridadou/openlaw/vm/OpenlawVmSpec.scala
@@ -605,7 +605,7 @@ class OpenlawVmSpec extends FlatSpec with Matchers {
     val definition = ContractDefinition(
       creatorId = UserId("hello@world.com"),
       mainTemplate = templateId,
-      templates = Map(),
+      templates = Map.empty,
       parameters = TemplateParameters()
     )
 


### PR DESCRIPTION
…emoves the risk that when we evaluate the nextActionSchedule we always get a date slightly after another now that we have

I've also added "now" and "creationDate" in OLInfo so we can use them in the language

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openlawteam/openlaw-core/229)
<!-- Reviewable:end -->
