### PR TITLE
reorg error message for EventFilter to avoid a misleading message say…

### DIFF
--- a/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/EthereumEventFilterType.scala
+++ b/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/EthereumEventFilterType.scala
@@ -135,9 +135,11 @@ case object EthereumEventFilterType
             Left(variableName)
           ) :: Nil =>
         propertyDef(variableName, expr, executionResult).map(_.typeDef)
-      case _ => Failure(
-        s"Ethereum event only support 'txt', 'received', 'executionDate' and 'event' invalid call with: ${keys.mkString(".")}"
-      )
+      case _ =>
+        Failure(
+          s"Ethereum event only support 'txt', 'received', 'executionDate' and 'event' invalid call with: ${keys
+            .mkString(".")}"
+        )
     }
 
   override def validateKeys(
@@ -196,7 +198,8 @@ case object EthereumEventFilterType
           } yield data
         case _ =>
           Failure(
-            s"Ethereum event only support 'txt', 'received', 'executionDate' and 'event' invalid call with: ${keys.mkString(".")}"
+            s"Ethereum event only support 'txt', 'received', 'executionDate' and 'event' invalid call with: ${keys
+              .mkString(".")}"
           )
       }
     }).flatten

--- a/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/EthereumEventFilterType.scala
+++ b/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/EthereumEventFilterType.scala
@@ -135,7 +135,9 @@ case object EthereumEventFilterType
             Left(variableName)
           ) :: Nil =>
         propertyDef(variableName, expr, executionResult).map(_.typeDef)
-      case _ => super.keysType(keys, expr, executionResult)
+      case _ => Failure(
+        s"Ethereum event only support 'txt', 'received', 'executionDate' and 'event' invalid call with: ${keys.mkString(".")}"
+      )
     }
 
   override def validateKeys(
@@ -194,7 +196,7 @@ case object EthereumEventFilterType
           } yield data
         case _ =>
           Failure(
-            s"Ethereum event only support one level of properties. invalid property access ${keys.mkString(".")}"
+            s"Ethereum event only support 'txt', 'received', 'executionDate' and 'event' invalid call with: ${keys.mkString(".")}"
           )
       }
     }).flatten


### PR DESCRIPTION
…ing that EthereumEventFilter type does not have properties (it does)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openlawteam/openlaw-core/230)
<!-- Reviewable:end -->
