### PR TITLE
buildStructureFromVariable should not take type definition into account

### DIFF
--- a/shared/src/main/scala/org/adridadou/openlaw/parser/template/ExpressionRules.scala
+++ b/shared/src/main/scala/org/adridadou/openlaw/parser/template/ExpressionRules.scala
@@ -299,13 +299,17 @@ trait ExpressionRules extends JsonRules {
 
   def parametersDefinition: Rule1[Parameter] = rule {
     parametersMapDefinition |
-      (oneOrMore(ws ~ (FunctionRule | ExpressionRule) ~ ws)
-        .separatedBy(",") ~> { s: Seq[Expression] =>
-        s.toList match {
-          case head :: Nil => OneValueParameter(head)
-          case lst         => ListParameter(lst)
-        }
-      })
+      valueParameterDefinition
+  }
+
+  def valueParameterDefinition: Rule1[Parameter] = rule {
+    oneOrMore(ws ~ (FunctionRule | ExpressionRule) ~ ws)
+      .separatedBy(",") ~> { s: Seq[Expression] =>
+      s.toList match {
+        case head :: Nil => OneValueParameter(head)
+        case lst         => ListParameter(lst)
+      }
+    }
   }
 
   def parametersMapDefinition: Rule1[Parameters] = rule {

--- a/shared/src/test/scala/org/adridadou/openlaw/vm/OpenlawExecutionEngineSpec.scala
+++ b/shared/src/test/scala/org/adridadou/openlaw/vm/OpenlawExecutionEngineSpec.scala
@@ -1940,7 +1940,7 @@ class OpenlawExecutionEngineSpec extends FlatSpec with Matchers {
     parser.compileTemplate(text) match {
       case Right(template) => template
       case Failure(ex, message) =>
-        fail(message, ex)
+        throw new RuntimeException(message, ex)
     }
 
   it should "be possible to add descriptions to properties of a Structure" in {
@@ -2760,5 +2760,26 @@ class OpenlawExecutionEngineSpec extends FlatSpec with Matchers {
     val text = parser.forReview(result.agreements.head)
 
     text shouldBe "<p class=\"no-section\"><br />hello world1234 hello worldcfc2206eabfdc5f3d9e7fa54f855a8c15d196c05 hello world2020-01-01T10:00<br />1234hello world 0xcfc2206eabfdc5f3d9e7fa54f855a8c15d196c05hello world 2020-01-01T10:00hello world</p>"
+  }
+
+  it should "be possible to define a structure within a structure" in {
+    val template =
+      compile("""
+        |[[struct a: Structure(
+        |a: Text;
+        |b: Number
+        |)]]
+        |
+        |[[struct b:Structure(
+        |a: struct a;
+        |b: struct a;
+        |c: Text)]]
+        |
+        |[[some value:struct b]]
+        |""".stripMargin)
+
+    val result = engine.execute(template).getOrThrow()
+
+    result.buildStructureValueFromVariables.getOrThrow()
   }
 }


### PR DESCRIPTION
fix issue where building a structure with type definition in the template results in an exception

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openlawteam/openlaw-core/232)
<!-- Reviewable:end -->
