### PR TITLE
minor bump scala/scala-builder patch versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# scala-builder:0.10.0-node blesses scala 2.12.10, sbt 1.2.8
-FROM openlaw/scala-builder:0.10.0-node
+# scala-builder:0.10.0-node blesses scala 2.12.11, sbt 1.2.8
+FROM openlaw/scala-builder:0.11.0-node
 
 # install plugins
 COPY project ./project

--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ always upgrade in a controlled fashion.
 If you wish to update either Scala or SBT, please open an issue and and tag
 @openlawteam/infra.
  */
-lazy val scalaV = "2.12.10"
+lazy val scalaV = "2.12.11"
 
 lazy val scalaJavaTimeV = "2.0.0-RC3"
 lazy val catsV = "1.6.1"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,7 +14,7 @@ addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.2")
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.4")
 
 /* ScalaJS related */
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.31")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.32")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.0")
 
 /* Release process */


### PR DESCRIPTION
This puts core on the same toolchain as openlaw-app.

Requires a ScalaJS patch version bump (within the 0.6.x series, 1.0.x has semver changes that someone would need to audit) to address compilation in Scala 2.12.11.