### PR TITLE
Fix pending external signature service calls.

### DIFF
--- a/shared/src/main/scala/org/adridadou/openlaw/oracles/ExternalCallOracle.scala
+++ b/shared/src/main/scala/org/adridadou/openlaw/oracles/ExternalCallOracle.scala
@@ -232,7 +232,8 @@ final case class PendingExternalCallEvent(
     executionDate: Instant
 ) extends ExternalCallEvent {
 
-  def isExternalSignature: Boolean = identifier.identifier.startsWith(SignatureAction.bulkRequestIdentifier)
+  def isExternalSignature: Boolean =
+    identifier.identifier.startsWith(SignatureAction.bulkRequestIdentifier)
 
   override def typeIdentifier: String = className[PendingExternalCallEvent]
 

--- a/shared/src/main/scala/org/adridadou/openlaw/oracles/ExternalCallOracle.scala
+++ b/shared/src/main/scala/org/adridadou/openlaw/oracles/ExternalCallOracle.scala
@@ -34,6 +34,13 @@ final case class ExternalCallOracle(
       handleFailedEvent(vm, failedEvent, failedEvent.scheduledDate)
     case successEvent: SuccessfulExternalCallEvent =>
       handleSuccessEvent(vm, successEvent)
+    case pending: PendingExternalCallEvent if pending.isExternalSignature =>
+      Success(
+        vm.newExecution(
+          event.identifier,
+          event.toExecution(event.executionDate)
+        )
+      )
     case _ =>
       handleEvent(vm, event)
   }
@@ -224,6 +231,9 @@ final case class PendingExternalCallEvent(
     requestIdentifier: RequestIdentifier,
     executionDate: Instant
 ) extends ExternalCallEvent {
+
+  def isExternalSignature: Boolean = identifier.identifier.startsWith(SignatureAction.bulkRequestIdentifier)
+
   override def typeIdentifier: String = className[PendingExternalCallEvent]
 
   override def serialize: String = this.asJson.noSpaces
@@ -233,7 +243,8 @@ final case class PendingExternalCallEvent(
   ): ExternalCallExecution = PendingExternalCallExecution(
     scheduledDate = scheduledDate,
     executionDate = executionDate,
-    requestIdentifier = requestIdentifier
+    requestIdentifier = requestIdentifier,
+    actionIdentifier = Some(identifier)
   )
 }
 

--- a/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/IdentityType.scala
+++ b/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/IdentityType.scala
@@ -198,8 +198,9 @@ final case class SignatureAction(
       case _ =>
         pastExecutions.find({
           case externalCall: PendingExternalCallExecution =>
-            externalCall.actionIdentifier.exists(_.identifier
-              .startsWith(SignatureAction.bulkRequestIdentifier)
+            externalCall.actionIdentifier.exists(
+              _.identifier
+                .startsWith(SignatureAction.bulkRequestIdentifier)
             )
           case _ => false
         }) match {

--- a/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/IdentityType.scala
+++ b/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/IdentityType.scala
@@ -182,6 +182,7 @@ final case class SignatureAction(
     email: Email,
     services: List[ServiceName] = List(ServiceName.openlawServiceName)
 ) extends ActionValue {
+
   override def nextActionSchedule(
       executionResult: TemplateExecutionResult,
       pastExecutions: List[OpenlawExecution]
@@ -197,8 +198,9 @@ final case class SignatureAction(
       case _ =>
         pastExecutions.find({
           case externalCall: PendingExternalCallExecution =>
-            externalCall.requestIdentifier.identifier
+            externalCall.actionIdentifier.exists(_.identifier
               .startsWith(SignatureAction.bulkRequestIdentifier)
+            )
           case _ => false
         }) match {
           case None if executionResult.hasSigned(email) => Success(None)

--- a/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/VariableType.scala
+++ b/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/VariableType.scala
@@ -202,7 +202,8 @@ object PendingExternalCallExecution {
 final case class PendingExternalCallExecution(
     scheduledDate: Instant,
     executionDate: Instant,
-    requestIdentifier: RequestIdentifier
+    requestIdentifier: RequestIdentifier,
+    actionIdentifier: Option[ActionIdentifier] = None
 ) extends ExternalCallExecution {
   def message: String =
     "the request has been submitted, waiting for the request to be executed"

--- a/shared/src/main/scala/org/adridadou/openlaw/vm/OpenlawVm.scala
+++ b/shared/src/main/scala/org/adridadou/openlaw/vm/OpenlawVm.scala
@@ -530,10 +530,13 @@ final case class OpenlawVm(
             templateOracle.incoming(this, e)
           case e: OpenlawVmInitEvent =>
             executeEvent(e)
+          case e: PendingExternalCallEvent if e.isExternalSignature =>
+            executeEvent(e)
           case _ =>
             logger.warn(
               "the virtual machine is in creation state. The only events allowed are signature events."
             )
+
             Success(this)
         }
       case _ => executeEvent(event)


### PR DESCRIPTION
We were not correctly executing pending external signature service calls
when the contract was in the 'created' state.

Our mechanism of checking if the call to the external signature service
had already been made was not working as the request ID was incorrectly
assumed to be the same thing as the action ID.