### PR TITLE
Add a new type for deferred external responses

### DIFF
--- a/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/ExternalCall.scala
+++ b/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/ExternalCall.scala
@@ -203,6 +203,11 @@ final case class DeferredResponse(
     expires: Option[Instant] = None
 )
 
+object DeferredResponse {
+  implicit val deferredResponseDec: Decoder[DeferredResponse] = deriveDecoder
+  implicit val deferredResponseEnc: Encoder[DeferredResponse] = deriveEncoder
+}
+
 final case class SignatureOutput(
     // Json representation of List[Email]
     signerEmailsJson: String,

--- a/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/ExternalCall.scala
+++ b/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/ExternalCall.scala
@@ -192,7 +192,7 @@ object SignatureInput {
 }
 
 /**
-  * A External Call response indicating that the response could tkae an extended amount time to
+  * A External Call response indicating that the response could take an extended amount time to
   * arrive (due to waiting on some action by a user, for example), and the ultimate completed response
   * will be given asynchronously.
   *

--- a/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/ExternalCall.scala
+++ b/shared/src/main/scala/org/adridadou/openlaw/parser/template/variableTypes/ExternalCall.scala
@@ -191,6 +191,18 @@ object SignatureInput {
   implicit val signatureInputEnc: Encoder[SignatureInput] = deriveEncoder
 }
 
+/**
+  * A External Call response indicating that the response could tkae an extended amount time to
+  * arrive (due to waiting on some action by a user, for example), and the ultimate completed response
+  * will be given asynchronously.
+  *
+  * @param expires when the request should be considered failed if no response comes before this time.
+  */
+final case class DeferredResponse(
+    // If a response isn't received by this time, the caller should consider the request to be expired
+    expires: Option[Instant] = None
+)
+
 final case class SignatureOutput(
     // Json representation of List[Email]
     signerEmailsJson: String,


### PR DESCRIPTION
A new external call response type that indicates the ultimate result will arrive later (when some user action is undertaken, for example.)